### PR TITLE
Do no raise exceptions for JSON requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::Base
   # Use custom error pages
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from Blacklight::Exceptions::RecordNotFound, with: :not_found
+  rescue_from ActionView::MissingTemplate, with: :not_found
 
   def not_found
     respond_to do |format|

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Errors", type: :request do
+  describe "unmatched routes" do
+    before do
+      get "/nonexistent_resource"
+    end
+
+    it "has an http status of 404" do
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "redirects to the custom not_found error page" do
+      expect(response.body).to include("The page you requested doesn't exist")
+    end
+  end
+
+  # Blacklight::Exceptions::RecordNotFound
+  describe "record not found" do
+    it "renders a 404 page" do
+      params = { id: "unknown_work" }
+      get "/catalog/#{params[:id]}"
+
+      expect(response.status).to eq(404)
+      expect(response.body).to include("The page you requested doesn't exist")
+    end
+  end
+
+  describe "json requests for the main page" do
+    it "returns a 404 status code response" do
+      get "/", params: { format: :json }
+      expect(response.status).to eq 404
+    end
+  end
+end


### PR DESCRIPTION
This PR will eliminate application errors being raised when JSON
requests come through.

Fixes #763