### PR TITLE
Add task to delete duplicate sidecars, resources

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -12,35 +12,62 @@ namespace :dpul do
         Spotlight::SolrDocumentSidecar.where(exhibit_id: exhibit_id, document_id: document_id).to_a
       end
 
+      # alternative strategy
       dup_sets.each do |ds|
         puts "solr document: #{ds.first.document_id}"
-        # for each set, if any sidecar has resource_id nil, delete that sidecar
-        linked_sidecars = ds.reject { |sidecar| sidecar.resource_id.nil? }
-        ds.select { |sidecar| sidecar.resource_id.nil? }.each do |sidecar|
-          puts " deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
-          # sidecar.destroy
-        end
+        # for each set, create a solr document
+        document = SolrDocument.new(repo.search(q: "id:#{ds.first.document_id}")["response"]["docs"].first)
 
-        # otherwise, get the solr document and see which resource_id it references
-        next unless linked_sidecars.count > 1
+        # delete the ones that we can't get to from that document
+        # see for example
+        # https://github.com/pulibrary/dpul/blob/09547ac7e7d9a21dc5b8dbc5437039e936e0d76f/app/views/spotlight/catalog/_edit_default.html.erb#L7
+        sidecar_to_keep = document.sidecar(ds.first.exhibit_id)
+        puts "  keeping sidecar last updated at #{sidecar_to_keep.updated_at}"
 
-        doc = repo.search(q: "id:#{linked_sidecars.first.document_id}")["response"]["docs"].first
-        good_resource_id = doc["spotlight_resource_id_ssim"].first.split("/").last
-        sidecars_to_delete = linked_sidecars.reject do |sidecar|
-          sidecar.resource_id == good_resource_id
-        end
-        # delete the other resource and sidecar (which may happen automatically
-        # when resource is deleted?)
+        sidecars_to_delete = ds - [sidecar_to_keep]
         sidecars_to_delete.each do |sidecar|
-          r = Spotlight::Resource.find(sidecar.resource_id)
-          puts " deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
-          # r.destroy
+          if sidecar.resource_id
+            r = Spotlight::Resource.find(sidecar.resource_id)
+            puts "  deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
+            # r.destroy
+          else # sidecar resource_id was nil
+            puts "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
+            # sidecar.destroy
+          end
         end
-        sidecar_to_keep = linked_sidecars.find do |sidecar|
-          sidecar.resource_id == good_resource_id
-        end
-        puts " keeping sidecar last updated at #{sidecar_to_keep.updated_at}"
       end
+
+      # Original strategy
+      #
+      # dup_sets.each do |ds|
+      #   puts "solr document: #{ds.first.document_id}"
+      #   # for each set, if any sidecar has resource_id nil, delete that sidecar
+      #   linked_sidecars = ds.reject { |sidecar| sidecar.resource_id.nil? }
+      #   ds.select { |sidecar| sidecar.resource_id.nil? }.each do |sidecar|
+      #     puts " deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
+      #     # sidecar.destroy
+      #   end
+      #
+      #   # otherwise, get the solr document and see which resource_id it references
+      #   next unless linked_sidecars.count > 1
+      #
+      #   doc = repo.search(q: "id:#{linked_sidecars.first.document_id}")["response"]["docs"].first
+      #   good_resource_id = doc["spotlight_resource_id_ssim"].first.split("/").last
+      #   sidecars_to_delete = linked_sidecars.reject do |sidecar|
+      #     sidecar.resource_id == good_resource_id
+      #   end
+      #   # delete the other resource and sidecar (which may happen automatically
+      #   # when resource is deleted?)
+      #   sidecars_to_delete.each do |sidecar|
+      #     r = Spotlight::Resource.find(sidecar.resource_id)
+      #     puts " deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
+      #     # r.destroy
+      #   end
+      #   sidecar_to_keep = linked_sidecars.find do |sidecar|
+      #     sidecar.resource_id == good_resource_id
+      #   end
+      #   puts " keeping sidecar last updated at #{sidecar_to_keep.updated_at}"
+      # end
     end
   end
 end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable
 namespace :dpul do
   namespace :cleanup do
     desc "delete duplicate sidecars"
@@ -51,15 +52,17 @@ namespace :dpul do
 
         sidecars_to_delete = ds - [sidecar_to_keep]
         sidecars_to_delete.each do |sidecar|
+          alternative_deletes << sidecar.id
           if sidecar.resource_id
-            r = Spotlight::Resource.find(sidecar.resource_id)
-            # puts "  deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
-            # r.destroy
+            if Spotlight::Resource.where(id: sidecar.resource_id).present?
+              r = Spotlight::Resource.find(sidecar.resource_id)
+              # puts "  deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
+              # r.destroy
+            end
           else # sidecar resource_id was nil
             # puts "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
             # sidecar.destroy
           end
-          alternative_deletes << sidecar.id
         end
       end; nil
       puts "kept: #{alternative_keeps}"
@@ -104,10 +107,15 @@ namespace :dpul do
         # delete the other resource and sidecar (which may happen automatically
         # when resource is deleted?)
         sidecars_to_delete.each do |sidecar|
-          r = Spotlight::Resource.find(sidecar.resource_id)
-          # puts " deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
           original_deletes << sidecar.id
-          # r.destroy
+          if Spotlight::Resource.where(id: sidecar.resource_id).present?
+            r = Spotlight::Resource.find(sidecar.resource_id)
+            # puts " deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
+            # r.destroy
+          else # sidecar resource_id was nil
+            # puts "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
+            # sidecar.destroy
+          end
         end
       end; nil
       puts "kept: #{original_keeps}"
@@ -116,3 +124,4 @@ namespace :dpul do
     end
   end
 end
+# rubocop:enable

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -29,14 +29,14 @@ namespace :dpul do
               # the resource referenced doesn't exist any longer
               if Spotlight::Resource.where(id: sidecar.resource_id).empty?
                 logger.info "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
-                # sidecar.destroy
+                sidecar.destroy
               else # sidecar resource id was a real resource
                 logger.info "  keeping sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
               end
             else
               # resource_id was nil
               logger.info "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
-              # sidecar.destroy
+              sidecar.destroy
             end
           end
           next
@@ -56,14 +56,14 @@ namespace :dpul do
             if Spotlight::Resource.where(id: sidecar.resource_id).present?
               r = Spotlight::Resource.find(sidecar.resource_id)
               logger.info "  deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
-              # r.destroy
+              r.destroy
             else # the resource didn't exist
               logger.info "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
-              # sidecar.destroy
+              sidecar.destroy
             end
           else # sidecar resource_id was nil
             logger.info "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
-            # sidecar.destroy
+            sidecar.destroy
           end
         end
       end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+namespace :dpul do
+  namespace :cleanup do
+    desc "delete duplicate sidecars"
+    task sidecars: :environment do
+      config = CatalogController.blacklight_config
+      repo = FriendlyIdRepository.new(config)
+      dups = Spotlight::SolrDocumentSidecar.select(:exhibit_id, :document_id).group(:exhibit_id, :document_id).having("count(*) > 1").size.keys
+
+      dup_sets = dups.map do |exhibit_id, document_id|
+        Spotlight::SolrDocumentSidecar.where(exhibit_id: exhibit_id, document_id: document_id).to_a
+      end
+
+      dup_sets.each do |ds|
+        # for each set, if any sidecar has resource_id nil, delete that sidecar
+        linked_sidecars = ds.reject { |sidecar| sidecar.resource_id.nil? }
+        ds.select { |sidecar| sidecar.resource_id.nil? }.each do |sidecar|
+          puts "deleting sidecar #{sidecar.id}"
+          # sidecar.destroy
+        end
+
+        # otherwise, get the solr document and see which resource_id it references
+        next unless linked_sidecars.count > 1
+
+        doc = repo.search(q: "id:#{linked_sidecars.first.document_id}")["response"]["docs"].first
+        good_resource_id = doc["spotlight_resource_id_ssim"].first.split("/").last
+        sidecars_to_delete = linked_sidecars.reject do |sidecar|
+          sidecar.resource_id == good_resource_id
+        end
+        # delete the other resource and sidecar (which may happen automatically
+        # when resource is deleted?)
+        sidecars_to_delete.each do |sidecar|
+          r = Spotlight::Resource.find(sidecar.resource_id)
+          puts "deleting resource #{r.id}"
+          # r.destroy
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -12,62 +12,107 @@ namespace :dpul do
         Spotlight::SolrDocumentSidecar.where(exhibit_id: exhibit_id, document_id: document_id).to_a
       end
 
+      alternative_deletes = []
+      alternative_keeps = []
       # alternative strategy
       dup_sets.each do |ds|
         puts "solr document: #{ds.first.document_id}"
         # for each set, create a solr document
-        document = SolrDocument.new(repo.search(q: "id:#{ds.first.document_id}")["response"]["docs"].first)
+        document_hash = repo.search(q: "id:#{ds.first.document_id}")["response"]["docs"].first
+
+        # In staging there was a pair where one had a nil resource id and the
+        # other referenced a resource that didn't exist in the db
+        if document_hash.nil?
+          puts "  solr document not found for resources #{ds.map(&:resource_id)}; sidecars #{ds.map(&:id)}"
+          ds.each do |sidecar|
+            if sidecar.resource_id
+              # the resource referenced doesn't exist any longer
+              if Spotlight::Resource.where(id: sidecar.resource_id).empty?
+                alternative_deletes << sidecar.id
+                # sidecar.destroy
+              end
+            else
+              # resource_id was nil
+              alternative_deletes << sidecar.id
+              # sidecar.destroy
+            end
+          end
+          next
+        end
+
+        document = SolrDocument.new(document_hash)
 
         # delete the ones that we can't get to from that document
         # see for example
         # https://github.com/pulibrary/dpul/blob/09547ac7e7d9a21dc5b8dbc5437039e936e0d76f/app/views/spotlight/catalog/_edit_default.html.erb#L7
         sidecar_to_keep = document.sidecar(ds.first.exhibit_id)
-        puts "  keeping sidecar last updated at #{sidecar_to_keep.updated_at}"
+        # puts "  keeping sidecar #{sidecar_to_keep.id} last updated at #{sidecar_to_keep.updated_at}"
+        alternative_keeps << sidecar_to_keep.id
 
         sidecars_to_delete = ds - [sidecar_to_keep]
         sidecars_to_delete.each do |sidecar|
           if sidecar.resource_id
             r = Spotlight::Resource.find(sidecar.resource_id)
-            puts "  deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
+            # puts "  deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
             # r.destroy
           else # sidecar resource_id was nil
-            puts "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
+            # puts "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
             # sidecar.destroy
           end
+          alternative_deletes << sidecar.id
         end
-      end
+      end; nil
+      puts "kept: #{alternative_keeps}"
+      puts "deleted: #{alternative_deletes}"
 
       # Original strategy
-      #
-      # dup_sets.each do |ds|
-      #   puts "solr document: #{ds.first.document_id}"
-      #   # for each set, if any sidecar has resource_id nil, delete that sidecar
-      #   linked_sidecars = ds.reject { |sidecar| sidecar.resource_id.nil? }
-      #   ds.select { |sidecar| sidecar.resource_id.nil? }.each do |sidecar|
-      #     puts " deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
-      #     # sidecar.destroy
-      #   end
-      #
-      #   # otherwise, get the solr document and see which resource_id it references
-      #   next unless linked_sidecars.count > 1
-      #
-      #   doc = repo.search(q: "id:#{linked_sidecars.first.document_id}")["response"]["docs"].first
-      #   good_resource_id = doc["spotlight_resource_id_ssim"].first.split("/").last
-      #   sidecars_to_delete = linked_sidecars.reject do |sidecar|
-      #     sidecar.resource_id == good_resource_id
-      #   end
-      #   # delete the other resource and sidecar (which may happen automatically
-      #   # when resource is deleted?)
-      #   sidecars_to_delete.each do |sidecar|
-      #     r = Spotlight::Resource.find(sidecar.resource_id)
-      #     puts " deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
-      #     # r.destroy
-      #   end
-      #   sidecar_to_keep = linked_sidecars.find do |sidecar|
-      #     sidecar.resource_id == good_resource_id
-      #   end
-      #   puts " keeping sidecar last updated at #{sidecar_to_keep.updated_at}"
-      # end
+
+      original_deletes = []
+      original_keeps = []
+      dup_sets.each do |ds|
+        # puts "solr document: #{ds.first.document_id}"
+        # for each set, if any sidecar has resource_id nil, delete that sidecar
+        linked_sidecars = ds.reject { |sidecar| sidecar.resource_id.nil? }
+        ds.select { |sidecar| sidecar.resource_id.nil? }.each do |sidecar|
+          # puts " deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
+          original_deletes << sidecar.id
+          # sidecar.destroy
+        end
+
+        # otherwise, get the solr document and see which resource_id it references
+        if linked_sidecars.count == 1
+          original_keeps << linked_sidecars.first.id
+        end
+        next unless linked_sidecars.count > 1
+
+        doc = repo.search(q: "id:#{linked_sidecars.first.document_id}")["response"]["docs"].first
+        good_resource_id = doc["spotlight_resource_id_ssim"].first.split("/").last
+
+        sidecar_to_keep = linked_sidecars.find do |sidecar|
+          sidecar.resource_id.to_s == good_resource_id.to_s
+        end
+        if sidecar_to_keep
+          # puts " keeping sidecar #{sidecar_to_keep.id} last updated at #{sidecar_to_keep.updated_at}"
+          original_keeps << sidecar_to_keep.id
+        end
+
+        sidecars_to_delete = linked_sidecars.reject do |sidecar|
+          sidecar.resource_id.to_s == good_resource_id.to_s
+        end
+        # puts "  sidecars to delete: #{sidecars_to_delete.map(&:id)}"
+
+        # delete the other resource and sidecar (which may happen automatically
+        # when resource is deleted?)
+        sidecars_to_delete.each do |sidecar|
+          r = Spotlight::Resource.find(sidecar.resource_id)
+          # puts " deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
+          original_deletes << sidecar.id
+          # r.destroy
+        end
+      end; nil
+      puts "kept: #{original_keeps}"
+      puts "deleted: #{original_deletes}"
+
     end
   end
 end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -5,6 +5,7 @@ namespace :dpul do
   namespace :cleanup do
     desc "delete duplicate sidecars"
     task sidecars: :environment do
+      logger = Logger.new(STDOUT)
       config = CatalogController.blacklight_config
       repo = FriendlyIdRepository.new(config)
       dups = Spotlight::SolrDocumentSidecar.select(:exhibit_id, :document_id).group(:exhibit_id, :document_id).having("count(*) > 1").size.keys
@@ -15,26 +16,26 @@ namespace :dpul do
 
       # alternative strategy
       dup_sets.each do |ds|
-        puts "solr document: #{ds.first.document_id}"
+        logger.info "solr document: #{ds.first.document_id}"
         # for each set, create a solr document
         document_hash = repo.search(q: "id:#{ds.first.document_id}")["response"]["docs"].first
 
         # In staging there was a pair where one had a nil resource id and the
         # other referenced a resource that didn't exist in the db
         if document_hash.nil?
-          puts "  solr document not found for resources #{ds.map(&:resource_id)}; sidecars #{ds.map(&:id)}"
+          logger.info "  solr document not found for resources #{ds.map(&:resource_id)}; sidecars #{ds.map(&:id)}"
           ds.each do |sidecar|
             if sidecar.resource_id
               # the resource referenced doesn't exist any longer
               if Spotlight::Resource.where(id: sidecar.resource_id).empty?
-                puts "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
+                logger.info "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
                 # sidecar.destroy
               else # sidecar resource id was a real resource
-                puts "  keeping sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
+                logger.info "  keeping sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
               end
             else
               # resource_id was nil
-              puts "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
+              logger.info "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
               # sidecar.destroy
             end
           end
@@ -47,26 +48,25 @@ namespace :dpul do
         # see for example
         # https://github.com/pulibrary/dpul/blob/09547ac7e7d9a21dc5b8dbc5437039e936e0d76f/app/views/spotlight/catalog/_edit_default.html.erb#L7
         sidecar_to_keep = document.sidecar(ds.first.exhibit_id)
-        puts "  keeping sidecar #{sidecar_to_keep.id} last updated at #{sidecar_to_keep.updated_at}"
+        logger.info "  keeping sidecar #{sidecar_to_keep.id} last updated at #{sidecar_to_keep.updated_at}"
 
         sidecars_to_delete = ds - [sidecar_to_keep]
         sidecars_to_delete.each do |sidecar|
           if sidecar.resource_id
             if Spotlight::Resource.where(id: sidecar.resource_id).present?
               r = Spotlight::Resource.find(sidecar.resource_id)
-              puts "  deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
+              logger.info "  deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
               # r.destroy
             else # the resource didn't exist
-              puts "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
+              logger.info "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
               # sidecar.destroy
             end
           else # sidecar resource_id was nil
-            puts "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
+            logger.info "  deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
             # sidecar.destroy
           end
         end
-      end; nil
-
+      end
     end
   end
 end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -13,10 +13,11 @@ namespace :dpul do
       end
 
       dup_sets.each do |ds|
+        puts "solr document: #{ds.first.document_id}"
         # for each set, if any sidecar has resource_id nil, delete that sidecar
         linked_sidecars = ds.reject { |sidecar| sidecar.resource_id.nil? }
         ds.select { |sidecar| sidecar.resource_id.nil? }.each do |sidecar|
-          puts "deleting sidecar #{sidecar.id}"
+          puts " deleting sidecar #{sidecar.id}, last updated at #{sidecar.updated_at}"
           # sidecar.destroy
         end
 
@@ -32,9 +33,13 @@ namespace :dpul do
         # when resource is deleted?)
         sidecars_to_delete.each do |sidecar|
           r = Spotlight::Resource.find(sidecar.resource_id)
-          puts "deleting resource #{r.id}"
+          puts " deleting resource #{r.id}, sidecar last updated at #{sidecar.updated_at}"
           # r.destroy
         end
+        sidecar_to_keep = linked_sidecars.find do |sidecar|
+          sidecar.resource_id == good_resource_id
+        end
+        puts " keeping sidecar last updated at #{sidecar_to_keep.updated_at}"
       end
     end
   end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable
 namespace :dpul do
   namespace :cleanup do
     desc "delete duplicate sidecars"
@@ -70,4 +69,3 @@ namespace :dpul do
     end
   end
 end
-# rubocop:enable


### PR DESCRIPTION
These are blocking upgrade due to a new uniqueness constraint on
sidecars for exhibit_id and document_id.
