### PR TITLE
Set fetch_many_document_params.

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -11,17 +11,11 @@ class BookmarksController < CatalogController
   end
 
   def csv
-    fetch_bookmarked_documents
+    _, @documents = action_documents
     send_data csv_output, type: 'text/csv', filename: "bookmarks-#{Time.zone.today}.csv"
   end
 
   private
-
-    def fetch_bookmarked_documents
-      bookmarks = token_or_current_or_guest_user.bookmarks
-      bookmark_ids = bookmarks.collect { |b| b.document_id.to_s }
-      _, @documents = fetch(bookmark_ids, rows: bookmark_ids.length)
-    end
 
     def csv_output
       CSV.generate(csv_bom, headers: true) do |csv|

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -56,6 +56,15 @@ class CatalogController < ApplicationController
       'group.facet': true
     }
 
+    config.fetch_many_document_params = {
+      fl: '*',
+      group: true,
+      'group.main': true,
+      'group.limit': 1,
+      'group.field': Spotlight::Engine.config.iiif_manifest_field,
+      'group.facet': true
+    }
+
     config.document_solr_path = 'get'
     config.document_unique_id_param = 'ids'
 


### PR DESCRIPTION
This removes the deprecation warning. It says it will be removed in Blacklight 7, but the new SearchService continues to use
fetch_many_document_params.

This also adjusts the BookmarksController to use Blacklight's API for it, so we won't have to change that.

Closes #937 