### PR TITLE
Remove authenticate and add_document_breadcrumb methods from local catalog controller

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -125,9 +125,5 @@ class CatalogController < ApplicationController
       format.json { render json: { response: { document: @document } } }
       additional_export_formats(@document, format)
     end
-
-    authenticate_user! && authorize!(:curate, current_exhibit) if @document.private? current_exhibit
-
-    add_document_breadcrumbs(@document)
   end
 end


### PR DESCRIPTION
We added these earlier in the upgrade, but we shouldn't have.