### PR TITLE
Remove error handling for a resource with no exhibit

### DIFF
--- a/app/presenters/rtl_show_presenter.rb
+++ b/app/presenters/rtl_show_presenter.rb
@@ -33,10 +33,6 @@ class RTLShowPresenter < ::Blacklight::ShowPresenter
     collection = Spotlight::Exhibit.where(title: value).first
     return value unless collection
 
-    unless view_context.respond_to?(:exhibit_path)
-      Rails.logger.error "Failed to render the link to the collection #{value} for #{collection.id}"
-      return value
-    end
     link_to collection.title, view_context.exhibit_path(collection)
   end
 

--- a/spec/features/catalog_show_spec.rb
+++ b/spec/features/catalog_show_spec.rb
@@ -68,28 +68,6 @@ RSpec.describe 'Catalog', type: :feature, js: true do
     expect(page).to have_link 'test collection 2', href: '/test-collection-2'
   end
 
-  context 'when the view_context is not available' do
-    # Ensures that this not a double
-    let(:view_context) { Object.new }
-    let(:collection1) { Spotlight::Exhibit.create!(title: 'test collection 1') }
-    let(:collection2) { Spotlight::Exhibit.create!(title: 'test collection 2') }
-
-    before do
-      allow(Rails.logger).to receive(:error)
-      allow_any_instance_of(RTLShowPresenter).to receive(:view_context).and_return(view_context)
-    end
-
-    it 'does not render the collection titles as links and logs an error' do
-      visit spotlight.exhibit_solr_document_path(exhibit, document_id)
-      expect(page).not_to have_link 'test collection 1'
-      expect(page).not_to have_link 'test collection 2'
-      expect(page).to have_content 'test collection 1'
-      expect(page).to have_content 'test collection 2'
-      expect(Rails.logger).to have_received(:error).with("Failed to render the link to the collection test collection 1 for #{collection1.id}")
-      expect(Rails.logger).to have_received(:error).with("Failed to render the link to the collection test collection 2 for #{collection2.id}")
-    end
-  end
-
   def index
     Blacklight.default_index.connection
   end


### PR DESCRIPTION
There should never be a resource with out an exhibit.

Closes https://github.com/pulibrary/dpul/issues/971