### PR TITLE
Turn on local override for render_search_bar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # This override keeps various layout templates from erroring when they check
+  # whether there's an exhibit selected
   def current_exhibit
     super
   rescue ActiveRecord::RecordNotFound

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,11 +5,11 @@ module ApplicationHelper
   include Spotlight::ApplicationHelper
   delegate :url, to: :universal_viewer, prefix: true
 
-  # def render_search_bar
-  #   super
-  # rescue StandardError
-  #   render partial: 'catalog/default_search_form'
-  # end
+  def render_search_bar
+    super
+  rescue StandardError
+    render partial: 'catalog/default_search_form'
+  end
 
   def site_sidebar?
     can?(:manage, Spotlight::Site.instance) || can?(:create, Spotlight::Exhibit)


### PR DESCRIPTION
This override keeps several tests passing. If we need to refactor could
we do it in a self-contained commit.

closes #997