### PR TITLE
Fix bookmarks.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,8 @@
 //= require jquery
 //= require jquery_ujs
 // Required by Blacklight
+//= require popper
+//= require bootstrap
 //= require blacklight/blacklight
 //= require 'blacklight_oembed/jquery.oembed.js'
 //= require blacklight_gallery

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -43,6 +43,8 @@ class CatalogController < ApplicationController
     # Make browse results doc actions consistent with search result doc actions
     config.browse.document_actions = config.index.document_actions
 
+    config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     # Group records by manifest in order to display a single result for a given
     # resource in 'search across'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -40,10 +40,9 @@ class CatalogController < ApplicationController
     config.show.partials.insert(1, :universal_viewer)
     config.view.embed(partials: ['universal_viewer'])
 
+    config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     # Make browse results doc actions consistent with search result doc actions
     config.browse.document_actions = config.index.document_actions
-
-    config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     # Group records by manifest in order to display a single result for a given

--- a/app/views/catalog/_bookmark_control.html.erb
+++ b/app/views/catalog/_bookmark_control.html.erb
@@ -1,27 +1,7 @@
-<% if current_or_guest_user %>
-  <%-
-  # Note these two forms are pretty similar but for different :methods, classes, and labels.
-  # but it was simpler to leave them seperate instead of DRYing them, got confusing trying that.
-  # the data-doc-id attribute is used by our JS that converts to a checkbox/label.
-  #
+<%-
   # Local override to use the actual document id for the form path as opposed to
   # the noid id. This simple change makes all the existing bookmark
   # functionality work rather than overriding functionality in several other
   # places to stay consistent with the noid.
-  -%>
-  <% unless bookmarked? document %>
-
-      <%= form_tag( bookmarks_id_path(document), :method => :put, :class => "bookmark_toggle", "data-doc-id" => document.id, :'data-present' => t('blacklight.search.bookmarks.present'), :'data-absent' => t('blacklight.search.bookmarks.absent'), :'data-inprogress' => t('blacklight.search.bookmarks.inprogress')) do %>
-        <%= submit_tag(t('blacklight.bookmarks.add.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "bookmark_add btn btn-default") %>
-      <% end %>
-
-  <% else %>
-
-      <%= form_tag( bookmarks_id_path(document), :method => :delete, :class => "bookmark_toggle", "data-doc-id" => document.id, :'data-present' => t('blacklight.search.bookmarks.present'), :'data-absent' => t('blacklight.search.bookmarks.absent'), :'data-inprogress' => t('blacklight.search.bookmarks.inprogress')) do %>
-        <%= submit_tag(t('blacklight.bookmarks.remove.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "bookmark_remove btn btn-default") %>
-      <% end %>
-
-  <% end %>
-<% else %>
-  &nbsp;
-<% end %>
+-%>
+<%= render Blacklight::Document::BookmarkComponent.new(document: document, bookmark_path: bookmarks_id_path(document)) if current_or_guest_user %>

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Bookmarks', type: :feature, js: true do
       iiif_resource1
       iiif_resource2
       visit spotlight.search_exhibit_catalog_path(exhibit, search_field: 'all_fields', q: '')
-      bookmark_box = "toggle_bookmark_#{solr_id}"
+      bookmark_box = "toggle-bookmark_#{solr_id}"
       check bookmark_box
       expect(page).to have_content "In Bookmarks"
 

--- a/spec/features/browse_spec.rb
+++ b/spec/features/browse_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe 'Browsing exhibits', type: :feature do
         expect(page).to have_css '.item-count', text: '1 item'
       end
 
-      it 'presents the bookmark action' do
+      it 'presents the bookmark action', js: true do
         expect(page).to have_content "Bookmark"
       end
     end


### PR DESCRIPTION
Enables Bootstrap/Blacklight JS
Replaces our bookmark form override with the new ViewComponent, passes the path
rather than overriding.

Closes #999
Closes #1008 
Closes #1006 
Closes #1000