### PR TITLE
Resolve document_show_link_field deprecation

### DIFF
--- a/app/helpers/index_helper.rb
+++ b/app/helpers/index_helper.rb
@@ -37,17 +37,9 @@ module IndexHelper
     [spotlight, exhibit, document]
   end
 
-  # Ensures that only a single string is passed from the IndexPresenter
-  # @param current_presenter [Class]
-  # @return [String]
-  def index_masonry_document_label(document)
-    field = field_from document: document
-    Array.wrap(field).first
-  end
-
   private
 
     def field_from(document:)
-      document_presenter(document).label(document_show_link_field(document))
+      document_presenter(document).heading
     end
 end

--- a/app/views/catalog/_index_masonry_default.html.erb
+++ b/app/views/catalog/_index_masonry_default.html.erb
@@ -1,1 +1,0 @@
-<%= link_to_document(document, truncate(index_masonry_document_label(document), length: 89)) %>

--- a/spec/helpers/index_helper_spec.rb
+++ b/spec/helpers/index_helper_spec.rb
@@ -24,41 +24,16 @@ describe IndexHelper do
     Object.send(:remove_const, :TestingHelper)
   end
 
-  describe '#index_masonry_document_label' do
-    subject(:output) { helper.index_masonry_document_label(document) }
-
-    let(:label) { 'title' }
-
-    before do
-      allow(helper).to receive(:document_presenter).and_return(document_presenter)
-      allow(helper).to receive(:document_show_link_field).and_return(:full_title_tesim)
-      allow(document_presenter).to receive(:label).and_return(label)
-    end
-
-    it 'retrieves the label using the title' do
-      expect(output).to eq 'title'
-    end
-
-    context 'when multiple titles exist' do
-      let(:label) { ['title1', 'title2'] }
-
-      it 'retrieves the label using only the first title' do
-        expect(output).to eq 'title1'
-      end
-    end
-  end
-
   describe '#render_index_document' do
     before do
       allow(helper).to receive(:document_presenter).and_return(document_presenter)
-      allow(helper).to receive(:document_show_link_field).and_return(:title)
       allow(helper).to receive(:url_for_document).and_return('link')
       allow(helper).to receive(:document_link_params).and_return({})
-      allow(document_presenter).to receive(:label).and_return(label)
+      allow(document_presenter).to receive(:heading).and_return(heading)
     end
 
-    context 'when given a ltr label' do
-      let(:label) { 'title' }
+    context 'when given a ltr heading' do
+      let(:heading) { 'title' }
 
       it 'returns a single ltr span tag' do
         tag = helper.render_index_document(document)
@@ -66,8 +41,8 @@ describe IndexHelper do
       end
     end
 
-    context 'when given a rtl label' do
-      let(:label) { 'تضيح المقال' }
+    context 'when given a rtl heading' do
+      let(:heading) { 'تضيح المقال' }
 
       it 'returns a single rtl span tag' do
         tag = helper.render_index_document(document)
@@ -76,7 +51,7 @@ describe IndexHelper do
     end
 
     context 'when given a multivalued title' do
-      let(:label) { ['تضيح المقال', 'title'] }
+      let(:heading) { ['تضيح المقال', 'title'] }
 
       it 'returns multiple span tags' do
         tag = helper.render_index_document(document)


### PR DESCRIPTION
Closes #994

- Uses `heading` method instead of deprecated `label` method in index presenter.
- Removes unused backlight gallery view override. See: https://github.com/pulibrary/dpul/issues/1017