### PR TITLE
Drop staging database before replicating prod

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -90,7 +90,7 @@ namespace :replicate do
       abort unless rails_env == 'staging'
       date = "2021-09-23" || ENV['DATE']
 
-      execute "cd '#{current_path}' && DATE=#{date} bundle exec rake dpul:replicate:prod"
+      execute "cd '#{current_path}' && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:drop && bundle exec rake db:create && DATE=#{date} bundle exec rake dpul:replicate:prod && bundle exec rake db:migrate"
     end
   end
 end

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -4,7 +4,15 @@ require 'i18n/backend/active_record'
 
 Translation = I18n::Backend::ActiveRecord::Translation
 
-if Translation.table_exists?
+# Guard to prevent errors when running rake db:create
+# Important when running replicate:prod cap task
+def database_exist?
+  return true if ActiveRecord::Base.connection
+rescue ActiveRecord::NoDatabaseError
+  false
+end
+
+if database_exist? && Translation.table_exists?
   ##
   # Sets up the new Spotlight Translation backend, backed by ActiveRecord. To
   # turn on the ActiveRecord backend, uncomment the following lines.


### PR DESCRIPTION
- Drop and re-create staging database before replicating the prod database.
- Run migrations after