### PR TITLE
Redesign breadcrumb

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,7 @@
 @import "overrides/buttons";
 @import "overrides/masthead";
 @import "overrides/masonry";
+@import "overrides/breadcrumb";
 @import "sir_trevor_widgets/featured_browse_categories";
 @import "sir_trevor_widgets/quote";
 @import "sir_trevor_widgets/widgets";

--- a/app/assets/stylesheets/overrides/breadcrumb.scss
+++ b/app/assets/stylesheets/overrides/breadcrumb.scss
@@ -1,4 +1,5 @@
 .breadcrumb {
   background-color: $white;
   padding: 0 0.5rem;
+  font-size: 0.9rem;
 }

--- a/app/assets/stylesheets/overrides/breadcrumb.scss
+++ b/app/assets/stylesheets/overrides/breadcrumb.scss
@@ -1,0 +1,4 @@
+.breadcrumb {
+  background-color: $white;
+  padding: 0 0.5rem;
+}

--- a/app/assets/stylesheets/overrides/breadcrumb.scss
+++ b/app/assets/stylesheets/overrides/breadcrumb.scss
@@ -1,5 +1,4 @@
 .breadcrumb {
-  background-color: $white;
-  padding: 0 0.5rem;
+  background-color: $light;
   font-size: 0.9rem;
 }


### PR DESCRIPTION
Closes #1132 

New:
<img width="1161" alt="Screen Shot 2021-10-15 at 5 00 04 PM" src="https://user-images.githubusercontent.com/66143640/137553056-b741ff98-dc14-4586-9d82-1157344bd43f.png">