### PR TITLE
Make title field config to_s delegate to field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -85,7 +85,8 @@ class CatalogController < ApplicationController
     config.document_unique_id_param = 'ids'
 
     # solr field configuration for search results/index views
-    config.index.title_field = ::Blacklight::Configuration::Field.new(field: Spotlight::Engine.config.iiif_title_fields, accessor: :title_or_override_title)
+    config.index.title_field = FieldStringifier.new(::Blacklight::Configuration::Field.new(field: Spotlight::Engine.config.iiif_title_fields, accessor: :title_or_override_title))
+
     config.index.display_title_field = 'readonly_title_tesim'
 
     config.add_search_field 'all_fields', label: 'Keyword'

--- a/app/decorators/field_stringifier.rb
+++ b/app/decorators/field_stringifier.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Spotlight assumes that the title field is the field name, but we need it to be
+# a Field object so it can fall back to override title. This makes it delegate
+# to_s to the field so that autocomplete works.
+class FieldStringifier < SimpleDelegator
+  def to_s
+    __getobj__.field.to_s
+  end
+end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -58,6 +58,12 @@ RSpec.feature 'Catalog', type: :feature do
       index.commit
     end
 
+    scenario 'user tries autocomplete' do
+      visit spotlight.autocomplete_exhibit_catalog_path(exhibit_id: exhibit.id, q: " ", format: "json")
+
+      expect(JSON.parse(page.body)["docs"].length).to eq 1
+    end
+
     scenario 'user searches for a collections with a keyword' do
       visit spotlight.search_exhibit_catalog_path(exhibit, search_field: 'all_fields', q: id)
       expect(page).to have_css '#documents .document h3.index_title', text: id


### PR DESCRIPTION
Fixes autocomplete without having to monkey-patch a method in Spotlight.

Closes #1157