### PR TITLE
Make exhibit card titles 2-lines max, with smaller font and uniform height

### DIFF
--- a/app/assets/stylesheets/overrides/exhibit_cards.scss
+++ b/app/assets/stylesheets/overrides/exhibit_cards.scss
@@ -1,7 +1,14 @@
-.exhibit-card .card-img-overlay {
-  background: rgba($light, $exhibit-card-overlay-opacity);
-}
+.exhibit-card {
+  padding-bottom: 4.125rem;
 
-.exhibit-card .card-title {
-  font-size: 16px;
+  .card-title {
+    -webkit-line-clamp: 2;
+    margin-top: 6px;
+    font-size: 16px;
+  }
+
+  .card-img-overlay {
+    background: rgba($light, $exhibit-card-overlay-opacity);
+    min-height: 4.125rem;
+  }
 }

--- a/app/assets/stylesheets/overrides/exhibit_cards.scss
+++ b/app/assets/stylesheets/overrides/exhibit_cards.scss
@@ -1,4 +1,7 @@
-.exhibit-card {
-  padding-bottom: 6rem;
-  min-height: 3.75em;
+.exhibit-card .card-img-overlay {
+  background: rgba($light, $exhibit-card-overlay-opacity);
+}
+
+.exhibit-card .card-title {
+  font-size: 16px;
 }

--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -40,3 +40,7 @@ ul {
 #content img {
   max-width: 100%;
 }
+
+.form-select.search-field {
+  background-color: $light;
+}

--- a/app/assets/stylesheets/variables/colors.scss
+++ b/app/assets/stylesheets/variables/colors.scss
@@ -16,3 +16,4 @@ $gray-dark: #666d78;
 $black: #2b2b2b;
 $green-light: #d6e9c6;
 $green-dark: #3c763d;
+$light: #f5f5f5;


### PR DESCRIPTION
[removed original description]

This is inspired by the stanford styling, but with the grey from our footer. It puts a 2-line max on titles to reduce awkward spaces and gives a uniform height to the title overlay to remove the bit of translucent popup from atop the bottom of the image when there's no hover. Font is smaller to make this all work with nice proportions.

 see screenshot in comment below.

refs #1041