### PR TITLE
Fix category title overflow

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@
 @import "overrides/breadcrumb";
 @import "overrides/exhibit_cards";
 @import "overrides/bookmarks";
+@import "overrides/browse_category";
 @import "sir_trevor_widgets/featured_browse_categories";
 @import "sir_trevor_widgets/quote";
 @import "sir_trevor_widgets/widgets";

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -1,5 +1,6 @@
-.browse-category, .browse-landing .category .image-overlay, .browse-landing .category .text-overlay {
-  box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2);
+.text-overlay {
+  /* Old style that washes out the background image of a browse category */
+  /* box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2); */
 
   .browse-category-title {
     margin-top: auto;
@@ -14,13 +15,7 @@
 }
 
 @media screen and (min-width: 768px) and (max-width: 1199.98px) {
-  .browse-category-title .title {
+  .text-overlay .browse-category-title .title {
     max-height: calc(1.5rem * 1.2 * 3);
   }
 }
-
-// @media screen and (max-width: 767.98px) {
-//   .browse-category-title .title {
-//     max-height: calc(1.75rem * 1.2 * 3);
-//   }
-// }

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -1,6 +1,6 @@
 .browse-landing .text-overlay {
-  /* Old style that washes out the background image of a browse category */
-  /* box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2); */
+  /* washes out the background image of a browse category */
+  box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2);
 
   .browse-category-title {
     margin-top: auto;

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -8,13 +8,19 @@
 
     .title {
       display: block;
-      max-height: calc(1.75rem * 1.2 * 3); /* font size * line-height * # of lines */
+      max-height: calc(1.75rem * 1.2 * 4); /* font size * line-height * # of lines */
       overflow: hidden;
     }
   }
 }
 
-@media screen and (min-width: 768px) and (max-width: 1199.98px) {
+@media screen and (min-width: 992px) and (max-width: 1199.98px) {
+  .text-overlay .browse-category-title .title {
+    max-height: calc(1.5rem * 1.2 * 4);
+  }
+}
+
+@media screen and (min-width: 768px) and (max-width: 991px) {
   .text-overlay .browse-category-title .title {
     max-height: calc(1.5rem * 1.2 * 3);
   }

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -32,9 +32,3 @@
     font-size: 1.25rem;
   }
 }
-
-@include media-breakpoint-down(md) {
-  .browse-landing .text-overlay .browse-category-title {
-    font-size: 1.5rem;
-  }
-}

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -13,17 +13,11 @@
   }
 }
 
-@include media-breakpoint-up(xl) {
-  .browse-landing .text-overlay .browse-category-title {
-    font-size: 1.5rem;
-
-    .title {
-      max-height: calc(1.5rem * 1.2 * 5); /* font size * line-height * # of lines */
-    }
-  }
-}
-
 @include media-breakpoint-down(xl) {
+  .browse-landing .text-overlay .browse-category-title {
+    font-size: 1.25rem;
+  }
+
   .browse-landing .text-overlay .browse-category-title .title {
     max-height: calc(1.25rem * 1.2 * 5);
   }
@@ -35,8 +29,12 @@
   }
 }
 
-@include media-breakpoint-down(xl) {
+@include media-breakpoint-up(xl) {
   .browse-landing .text-overlay .browse-category-title {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
+
+    .title {
+      max-height: calc(1.5rem * 1.2 * 5); /* font size * line-height * # of lines */
+    }
   }
 }

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -3,25 +3,62 @@
   /* box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2); */
 
   .browse-category-title {
+    font-size: 1.5rem;
     margin-top: auto;
     margin-bottom: auto;
 
     .title {
       display: block;
-      max-height: calc(1.75rem * 1.2 * 4); /* font size * line-height * # of lines */
+      max-height: calc(1.5rem * 1.2 * 5); /* font size * line-height * # of lines */
       overflow: hidden;
     }
   }
 }
 
-@media screen and (min-width: 992px) and (max-width: 1199.98px) {
-  .text-overlay .browse-category-title .title {
-    max-height: calc(1.5rem * 1.2 * 4);
+@include media-breakpoint-between(md, xl) {
+  .text-overlay .browse-category-title {
+    font-size: 1.25rem;
   }
 }
 
-@media screen and (min-width: 768px) and (max-width: 991px) {
+@include media-breakpoint-between(lg, xl) {
   .text-overlay .browse-category-title .title {
-    max-height: calc(1.5rem * 1.2 * 3);
+    max-height: calc(1.25rem * 1.2 * 5);
   }
 }
+
+@include media-breakpoint-between(md, lg) {
+  .text-overlay .browse-category-title .title {
+    max-height: calc(1.25rem * 1.2 * 4);
+  }
+}
+
+@include media-breakpoint-down(md) {
+  .text-overlay .browse-category-title {
+    font-size: 1.5rem;
+  }
+}
+
+// @media screen and (min-width: 768px) and (max-width: 1199.98px) {
+//   .text-overlay .browse-category-title {
+//     font-size: 1.25rem;
+//   }
+// }
+//
+// @media screen and (min-width: 992px) and (max-width: 1199.98px) {
+//   .text-overlay .browse-category-title .title {
+//     max-height: calc(1.25rem * 1.2 * 5);
+//   }
+// }
+//
+// @media screen and (min-width: 768px) and (max-width: 991px) {
+//   .text-overlay .browse-category-title .title {
+//     max-height: calc(1.25rem * 1.2 * 4);
+//   }
+// }
+//
+// @media screen and (max-width: 767.98px) {
+//   .text-overlay .browse-category-title {
+//     font-size: 1.5rem;
+//   }
+// }

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -1,3 +1,26 @@
 .browse-category, .browse-landing .category .image-overlay, .browse-landing .category .text-overlay {
 	box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2)
+
+  .browse-category-title {
+    margin-top: auto;
+    margin-bottom: auto;
+
+    .title {
+      display: block;
+      max-height: calc(1.75rem * 1.2 * 3); /* font size * line-height * # of lines */
+      overflow: hidden;
+    }
+  }
 }
+
+@media screen and (min-width: 768px) and (max-width: 1199.98px) {
+  .browse-category-title .title {
+    max-height: calc(1.5rem * 1.2 * 3);
+  }
+}
+
+// @media screen and (max-width: 767.98px) {
+//   .browse-category-title .title {
+//     max-height: calc(1.75rem * 1.2 * 3);
+//   }
+// }

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -3,14 +3,22 @@
   /* box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2); */
 
   .browse-category-title {
-    font-size: 1.5rem;
     margin-top: auto;
     margin-bottom: auto;
 
     .title {
       display: block;
-      max-height: calc(1.5rem * 1.2 * 5); /* font size * line-height * # of lines */
       overflow: hidden;
+    }
+  }
+}
+
+@include media-breakpoint-up(xl) {
+  .browse-landing .text-overlay .browse-category-title {
+    font-size: 1.5rem;
+
+    .title {
+      max-height: calc(1.5rem * 1.2 * 5); /* font size * line-height * # of lines */
     }
   }
 }

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -1,4 +1,4 @@
-.text-overlay {
+.browse-landing .text-overlay {
   /* Old style that washes out the background image of a browse category */
   /* box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2); */
 
@@ -16,25 +16,25 @@
 }
 
 @include media-breakpoint-between(md, xl) {
-  .text-overlay .browse-category-title {
+  .browse-landing .text-overlay .browse-category-title {
     font-size: 1.25rem;
   }
 }
 
 @include media-breakpoint-between(lg, xl) {
-  .text-overlay .browse-category-title .title {
+  .browse-landing .text-overlay .browse-category-title .title {
     max-height: calc(1.25rem * 1.2 * 5);
   }
 }
 
 @include media-breakpoint-between(md, lg) {
-  .text-overlay .browse-category-title .title {
+  .browse-landing .text-overlay .browse-category-title .title {
     max-height: calc(1.25rem * 1.2 * 4);
   }
 }
 
 @include media-breakpoint-down(md) {
-  .text-overlay .browse-category-title {
+  .browse-landing .text-overlay .browse-category-title {
     font-size: 1.5rem;
   }
 }

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -38,27 +38,3 @@
     font-size: 1.5rem;
   }
 }
-
-// @media screen and (min-width: 768px) and (max-width: 1199.98px) {
-//   .text-overlay .browse-category-title {
-//     font-size: 1.25rem;
-//   }
-// }
-//
-// @media screen and (min-width: 992px) and (max-width: 1199.98px) {
-//   .text-overlay .browse-category-title .title {
-//     max-height: calc(1.25rem * 1.2 * 5);
-//   }
-// }
-//
-// @media screen and (min-width: 768px) and (max-width: 991px) {
-//   .text-overlay .browse-category-title .title {
-//     max-height: calc(1.25rem * 1.2 * 4);
-//   }
-// }
-//
-// @media screen and (max-width: 767.98px) {
-//   .text-overlay .browse-category-title {
-//     font-size: 1.5rem;
-//   }
-// }

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -1,5 +1,5 @@
 .browse-category, .browse-landing .category .image-overlay, .browse-landing .category .text-overlay {
-	box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2)
+  box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2)
 
   .browse-category-title {
     margin-top: auto;

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -15,13 +15,7 @@
   }
 }
 
-@include media-breakpoint-between(md, xl) {
-  .browse-landing .text-overlay .browse-category-title {
-    font-size: 1.25rem;
-  }
-}
-
-@include media-breakpoint-between(lg, xl) {
+@include media-breakpoint-down(xl) {
   .browse-landing .text-overlay .browse-category-title .title {
     max-height: calc(1.25rem * 1.2 * 5);
   }
@@ -30,6 +24,12 @@
 @include media-breakpoint-between(md, lg) {
   .browse-landing .text-overlay .browse-category-title .title {
     max-height: calc(1.25rem * 1.2 * 4);
+  }
+}
+
+@include media-breakpoint-down(xl) {
+  .browse-landing .text-overlay .browse-category-title {
+    font-size: 1.25rem;
   }
 }
 

--- a/app/assets/stylesheets/overrides/browse_category.scss
+++ b/app/assets/stylesheets/overrides/browse_category.scss
@@ -1,5 +1,5 @@
 .browse-category, .browse-landing .category .image-overlay, .browse-landing .category .text-overlay {
-  box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2)
+  box-shadow: inset 0 0 1px 250px rgba(196,194,194,0.2);
 
   .browse-category-title {
     margin-top: auto;


### PR DESCRIPTION
Closes #1166 

Note these screenshots show the wash-out effect removed, but it's been replaced to give us a bit more contrast for text legibility.

full screen size:

![Screen Shot 2021-11-01 at 10 46 18 AM](https://user-images.githubusercontent.com/845363/139690825-d8c2ec5b-6117-4394-824f-b2e9e0910bc8.png)


tablet size (longer titles don't show completely):

![Screen Shot 2021-11-01 at 10 46 53 AM](https://user-images.githubusercontent.com/845363/139690842-2502a9f7-54a1-46f4-abf7-68c3216c99a2.png)
