### PR TITLE
Fix masthead title overflow on smaller screen widths

### DIFF
--- a/app/assets/stylesheets/overrides/masthead.scss
+++ b/app/assets/stylesheets/overrides/masthead.scss
@@ -1,11 +1,22 @@
-// Increase exhibit masthead title sizes
-.masthead .site-title-wrapper {
-  // Original value: 2rem.
-  .site-title {
+// Increase exhibit masthead title sizes and let it wrap
+.masthead {
+  .site-title-container {
+    // Original value: 9.375rem
+    max-height: none;
+  }
+
+  .site-title-wrapper {
+    // Original value: nowrap
+    white-space: normal;
+
+    // Original value: 2rem
+    .site-title {
       font-size: 2.25rem;
     }
-  // Original value: 1.0125rem
-  small {
-    font-size: 1.463rem;
+
+    // Original value: 1.0125rem
+    small {
+      font-size: 1.463rem;
+    }
   }
 }


### PR DESCRIPTION
Closes #1182 

BEFORE
<img width="790" alt="Screen Shot 2021-10-29 at 1 55 21 PM" src="https://user-images.githubusercontent.com/66143640/139500478-1e207e7e-a47b-41b8-9a71-c440e7f4311d.png">

AFTER
<img width="799" alt="Screen Shot 2021-10-29 at 4 53 39 PM" src="https://user-images.githubusercontent.com/66143640/139500471-fcf798e7-0435-43fa-a61d-2eebe98aa902.png">