### PR TITLE
Resources without exhibits should not break bookmarks.

### DIFF
--- a/app/helpers/index_helper.rb
+++ b/app/helpers/index_helper.rb
@@ -34,7 +34,11 @@ module IndexHelper
   def contextual_url_for_document(document, exhibit)
     return nil if document.nil?
 
-    [spotlight, exhibit, document]
+    if exhibit
+      [spotlight, exhibit, document]
+    else
+      [main_app, document]
+    end
   end
 
   private

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe 'Bookmarks', type: :feature, js: true do
 
       visit "/catalog?search_field=all_fields&q="
       expect(page).to have_content "In Bookmarks"
+
+      # Exhibit was destroyed, leaving an orphaned Resource.
+      # @TODO Make this case impossible to reach.
+      exhibit.destroy
+      visit "/bookmarks"
+      expect(page).to have_content "1 entry found"
     end
   end
 end


### PR DESCRIPTION
Closes #1165

See #1188 for a ticket that should make this workaround removable.