### PR TITLE
Fix bulk tag updates

### DIFF
--- a/app/controllers/bulk_actions_controller.rb
+++ b/app/controllers/bulk_actions_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Override Spotlight::BulkActionsController to enable the `add_tags`,
+# `remove_tags`, and `change_visibility` methods.
+class BulkActionsController < Spotlight::BulkActionsController
+  # Get solr params and remove group parameters. These were added to enable
+  # search across and are incompatible with the Solr cursorMark used in the
+  # Spotlight `each_document` method.
+  # See: https://github.com/projectblacklight/spotlight/blob/v3.0.3/app/jobs/spotlight/add_tags_job.rb#L14
+  # See: https://github.com/projectblacklight/spotlight/blob/v3.0.3/app/jobs/concerns/spotlight/gather_documents.rb#L10
+  def solr_params
+    solr_response.request_params.tap do |p|
+      p.delete("group")
+      p.delete("group.main")
+      p.delete("group.facet")
+      p.delete("group.limit")
+      p.delete("group.field")
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,12 @@ Rails.application.routes.draw do
     end
   end
   resources :exhibits, path: '/', only: [:create, :update, :destroy]
+
+  # Override the Spotlight bulk actions routes to use local BulkActionsController
+  post '/:exhibit_id/bulk_actions/change_visibility', as: "change_visibility_exhibit_bulk_actions", to: 'bulk_actions#change_visibility'
+  post '/:exhibit_id/bulk_actions/add_tags', as: "add_tags_exhibit_bulk_actions", to: 'bulk_actions#add_tags'
+  post '/:exhibit_id/bulk_actions/remove_tags', as: "remove_tags_exhibit_bulk_actions", to: 'bulk_actions#remove_tags'
+
   match '/:exhibit_id/metadata_configuration', to: 'pomegranate/metadata_configurations#update', via: [:patch, :put]
 
   # root to: "catalog#index" # replaced by spotlight root path

--- a/spec/features/bulk_actions_spec.rb
+++ b/spec/features/bulk_actions_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Bulk actions', type: :feature do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:admin) { FactoryBot.create(:exhibit_admin, exhibit: exhibit) }
+
+  before do
+    sign_in admin
+    d = SolrDocument.new(id: 'dq287tq6352')
+    exhibit.tag(d.sidecar(exhibit), with: ['foo'], on: :tags)
+    d.make_private! exhibit
+    d.reindex
+    Blacklight.default_index.connection.commit
+  end
+
+  it 'adding tags', js: true do
+    visit spotlight.search_exhibit_catalog_path(exhibit, q: 'dq287tq6352')
+
+    click_button 'Bulk actions'
+    click_link 'Add tags'
+    expect(page).to have_css 'h4', text: 'Add tags', visible: true
+    within '#add-tags-modal' do
+      find('[data-autocomplete-fetched="true"]', visible: false)
+      find('.tt-input').set('good,stuff')
+    end
+    accept_confirm 'All items in the result set will be updated. Are you sure?' do
+      click_button 'Add'
+    end
+    expect(page).to have_css '.alert', text: 'Tags are being added for 1 item.'
+    expect(SolrDocument.new(id: 'dq287tq6352').sidecar(exhibit).all_tags_list).to include('foo', 'good', 'stuff')
+  end
+end


### PR DESCRIPTION
- Fixes bulk tag updates by overriding BulkActionsController and removing grouping parameters
- The issue arises because we use group params to enable search across and they are incompatible with Spotlight's method use of the Solr cursorMark to paginate over groups of documents.
- I tried a variety of methods to inject this was the only one that worked completely.

Closes #1172 