### PR TITLE
Convert link_to_search checkbox to link_to_facet

### DIFF
--- a/app/controllers/pomegranate/metadata_configurations_controller.rb
+++ b/app/controllers/pomegranate/metadata_configurations_controller.rb
@@ -10,7 +10,7 @@ module Pomegranate
         views = @blacklight_configuration.default_blacklight_config.view.keys | [:show]
 
         @blacklight_configuration.blacklight_config.index_fields.keys.each_with_object({}) do |element, result|
-          result[element] = (%i[enabled label weight text_area link_to_search] | views)
+          result[element] = (%i[enabled label weight text_area link_to_facet] | views)
         end
       end
   end

--- a/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
+++ b/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
@@ -17,7 +17,7 @@
     <% available_view_fields.keys.each do |type| %>
       <td class="checkbox-cell text-center"><%= field.check_box type, inline: true, checked: config.send(type), label: "" %></td>
     <% end %>
-    <% # Customized - add link to search option %>
-    <td class="checkbox-cell text-center"><%= field.check_box :link_to_search, {inline: true, checked: config.link_to_search.present?, label: ""}, config.field, false%></td>
+    <% # Customized - add link to facet option %>
+    <td class="checkbox-cell text-center"><%= field.check_box :link_to_facet, {inline: true, checked: config.link_to_facet.present?, label: ""}, config.field, false%></td>
   <% end %>
 </tr>

--- a/spec/views/spotlight/metadata_configurations/_metadata_field.html.erb_spec.rb
+++ b/spec/views/spotlight/metadata_configurations/_metadata_field.html.erb_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe 'spotlight/metadata_configurations/_metadata_field', type: :view 
     expect(rendered).not_to have_selector '.import-tooltip'
   end
 
-  it "renders a field to set link_to_search" do
+  it "renders a field to set link_to_facet" do
     Spotlight::CustomField.create!(exhibit: exhibit, slug: "two", field: "two", label: "two", field_type: "vocab", readonly_field: false)
     allow(view).to receive(:index_field_label).with(nil, 'two').and_return 'Some label'
     render partial: p, locals: { key: 'two', config: facet_field, f: builder }
 
-    expect(rendered).to have_selector "input[type=checkbox][name='z[two][link_to_search]']"
+    expect(rendered).to have_selector "input[type=checkbox][name='z[two][link_to_facet]']"
   end
 end


### PR DESCRIPTION
Updates "Link to search" checkbox to Blacklight 7 compatible "Link to facet".

Closes #1199 