### PR TITLE
Make exhibit card subtitle smaller

### DIFF
--- a/app/assets/stylesheets/overrides/exhibit_cards.scss
+++ b/app/assets/stylesheets/overrides/exhibit_cards.scss
@@ -11,4 +11,8 @@
     background: rgba($light, $exhibit-card-overlay-opacity);
     min-height: 4.125rem;
   }
+
+  .subtitle {
+    font-size: 0.875rem;
+  }
 }


### PR DESCRIPTION
Closes #1192 

Before:
<img width="274" alt="Screen Shot 2021-11-05 at 4 35 56 PM" src="https://user-images.githubusercontent.com/66143640/140575315-4ec41efe-f08f-4922-b4c9-8121a008b836.png">

After:
<img width="276" alt="Screen Shot 2021-11-05 at 4 36 44 PM" src="https://user-images.githubusercontent.com/66143640/140575386-bb109c2f-b00a-4a8a-874d-8fc3cc35f864.png">

