### PR TITLE
Alphabetize tags case insensitively

### DIFF
--- a/app/views/spotlight/exhibits/_tags.html.erb
+++ b/app/views/spotlight/exhibits/_tags.html.erb
@@ -4,7 +4,7 @@ as overriding css text-align properties would create a confusing/false class nam
   <ul class="nav nav-pills tags">
     <%= nav_link t('.all'), exhibits_path, active: params[:tag].blank? %>
 
-    <% tags.sort_by(&:name).each do |tag| %>
+    <% tags.sort_by { |tag| tag.name.downcase }.each do |tag| %>
       <%= nav_link tag.name, exhibits_path(tag: tag.name), active: params[:tag] == tag.name %>
     <% end %>
   </ul>


### PR DESCRIPTION
Closes #1150 

The tags were being alphabetized but case sensitively, which is why the tags starting with lowercase letters are at the end of the tag list. I fixed this by sorting case insensitively.