### PR TITLE
Store the non-exhibit-prefixed facet name in link_to_facet

### DIFF
--- a/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
+++ b/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
@@ -18,6 +18,6 @@
       <td class="checkbox-cell text-center"><%= field.check_box type, inline: true, checked: config.send(type), label: "" %></td>
     <% end %>
     <% # Customized - add link to facet option %>
-    <td class="checkbox-cell text-center"><%= field.check_box :link_to_facet, {inline: true, checked: config.link_to_facet.present?, label: ""}, config.field, false%></td>
+    <td class="checkbox-cell text-center"><%= field.check_box :link_to_facet, {inline: true, checked: config.link_to_facet.present?, label: ""}, config.key, false%></td>
   <% end %>
 </tr>

--- a/spec/features/catalog_show_spec.rb
+++ b/spec/features/catalog_show_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe 'Catalog', type: :feature, js: true do
         ],
         'content_metadata_iiif_manifest_field_ssi': [
           'http://images.institution.edu'
+        ],
+        "exhibit_exhibit-title-1_readonly_author_ssim": [
+          "Vasi"
+        ],
+        "readonly_author_tesim": [
+          "Vasi"
         ]
       }
     )
@@ -66,6 +72,16 @@ RSpec.describe 'Catalog', type: :feature, js: true do
     visit spotlight.exhibit_solr_document_path(exhibit, document_id)
     expect(page).to have_link 'test collection 1', href: '/test-collection-1'
     expect(page).to have_link 'test collection 2', href: '/test-collection-2'
+  end
+
+  it "renders the correct facet link" do
+    # the value of link_to_facet into the configuration needs to match the field name
+    exhibit.blacklight_configuration.index_fields["readonly_author_ssim"] = { "label" => "Author", "link_to_facet" => "readonly_author_ssim", "list" => true, "show" => true, "enabled" => true }
+    exhibit.blacklight_configuration.save
+    Spotlight::CustomField.create!(exhibit: exhibit, slug: 'author', field: 'readonly_author_ssim', configuration: { "label" => "Author" }, field_type: 'vocab', readonly_field: true)
+
+    visit spotlight.exhibit_solr_document_path(exhibit, document_id)
+    expect(page).to have_link 'Vasi', href: '/exhibit-title-1/catalog?f%5Breadonly_author_ssim%5D%5B%5D=Vasi'
   end
 
   def index

--- a/spec/views/spotlight/metadata_configurations/_metadata_field.html.erb_spec.rb
+++ b/spec/views/spotlight/metadata_configurations/_metadata_field.html.erb_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'spotlight/metadata_configurations/_metadata_field', type: :view 
     )
   end
 
-  let(:facet_field) { Blacklight::Configuration::FacetField.new }
+  let(:facet_field) { exhibit.blacklight_configuration.blacklight_config.index_fields["two"] }
   let(:builder) { ActionView::Helpers::FormBuilder.new 'z', nil, view, {} }
 
   it 'renders a tooltip for imported fields' do
@@ -40,6 +40,6 @@ RSpec.describe 'spotlight/metadata_configurations/_metadata_field', type: :view 
     allow(view).to receive(:index_field_label).with(nil, 'two').and_return 'Some label'
     render partial: p, locals: { key: 'two', config: facet_field, f: builder }
 
-    expect(rendered).to have_selector "input[type=checkbox][name='z[two][link_to_facet]']"
+    expect(rendered).to have_selector "input[type=checkbox][name='z[two][link_to_facet]'][value='two']"
   end
 end


### PR DESCRIPTION
This is what is used for lookup to find the right facet field

closes #1199 again

Note that once this is deployed any exhibits with broken facet links can be repaired by going into the exhibit dashboard > Metadata Display > click "save" on the form (this will overwrite the saved value of this field with the correct value)