### PR TITLE
Add Faraday timeout value to http_client connections

### DIFF
--- a/app/services/iiif_service.rb
+++ b/app/services/iiif_service.rb
@@ -2,7 +2,7 @@
 
 class IiifService < ::Spotlight::Resources::IiifService
   def self.iiif_response(url)
-    resp = Faraday.get(url)
+    resp = Spotlight::Resources::IiifService.http_client.get(url)
     if resp.success?
       resp.body
     else

--- a/config/initializers/monkeypatches/iiif_service_patch.rb
+++ b/config/initializers/monkeypatches/iiif_service_patch.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spotlight/resources/iiif_service'
+
+module Spotlight
+  module Resources
+    class IiifService
+      # Overridden to set a larger timeout value.
+      # Some of our manifests take a long time time to load.
+      def self.http_client
+        Faraday.new(request: { timeout: 60 }) do |b|
+          b.use FaradayMiddleware::FollowRedirects
+          b.adapter Faraday.default_adapter
+        end
+      end
+    end
+  end
+end

--- a/spec/services/iiif_service_spec.rb
+++ b/spec/services/iiif_service_spec.rb
@@ -8,6 +8,7 @@ describe IiifService do
 
     let(:url) { 'http://to-manifest1' }
     let(:http_response) { instance_double(Faraday::Response) }
+    let(:http_client) { instance_double(Faraday::Connection) }
     let(:logger) { instance_double(ActiveSupport::Logger) }
     let(:manifest_fixture) { test_manifest1 }
 
@@ -17,7 +18,8 @@ describe IiifService do
       allow(http_response).to receive(:success?).and_return(true)
       # Return the default fixture as the remotely referenced JSON-LD expression
       allow(http_response).to receive(:body).and_return(manifest_fixture)
-      allow(Faraday).to receive(:get).and_return(http_response)
+      allow(Spotlight::Resources::IiifService).to receive(:http_client).and_return(http_client)
+      allow(http_client).to receive(:get).and_return(http_response)
     end
 
     after do
@@ -46,7 +48,7 @@ describe IiifService do
 
     context 'when the request times out' do
       before do
-        allow(Faraday).to receive(:get).and_raise(Faraday::TimeoutError)
+        allow(http_client).to receive(:get).and_raise(Faraday::TimeoutError)
         allow(logger).to receive(:warn)
         allow(Rails).to receive(:logger).and_return(logger)
       end


### PR DESCRIPTION
- In a previous commit, we increased a timeout value, but this did not solve our timeout issues. 
- We need to set a timeout value on the Spotlight http_client and configure the DPUL IIIFService class to use it.
- Also important for resolving #1226, is that the[ IiifHarverster.url_is_iiif?](https://github.com/projectblacklight/spotlight/blob/master/app/models/spotlight/resources/iiif_harvester.rb#L36) method uses the larger timeout as well.
- As this is not configurable currently, the only (semi) sane way to do this is to monkey patch.

Advances #1226