### PR TITLE
Fix exhibit re-indexing information display

### DIFF
--- a/app/jobs/concerns/job_tracking.rb
+++ b/app/jobs/concerns/job_tracking.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Overrides a handful of Spotlight JobTacking concern methods to allow accurate
+# tracking of Princeton exhibit reindex jobs
+# See: https://github.com/projectblacklight/spotlight/blob/v3.0.3/app/jobs/concerns/spotlight/job_tracking.rb
+module JobTracking
+  extend ActiveSupport::Concern
+  include ActiveJob::Status
+
+  class_methods do
+    # Override to initialize the job tracker on enqueue so that that the total
+    # number of tracked jobs is known upfront. Improves the quality of metrics
+    # displayed to the user.
+    def with_job_tracking(
+      resource:,
+      reports_on: ->(job) { job.arguments.last[:reports_on] if job.arguments.last.is_a?(Hash) },
+      user: ->(job) { job.arguments.last[:user] if job.arguments.last.is_a?(Hash) }
+    )
+      around_enqueue do |job, block|
+        job.initialize_job_tracker(job, resource, reports_on, user)
+        block.call
+      end
+
+      around_perform do |job, block|
+        job.initialize_job_tracker(job, resource, reports_on, user)
+        block.call
+      ensure
+        job.finalize_job_tracker!
+      end
+    end
+  end
+
+  # Override to initialize a new tracker with all necessary params and a data
+  # attribute that shows an accurate resource total. This total is summed from
+  # all job trackers.
+  def initialize_job_tracker(job, resource, reports_on, user)
+    resource_object = resource&.call(job)
+    params = {
+      job_id: job_id,
+      resource: resource_object,
+      on: reports_on&.call(job) || resource_object,
+      user: user&.call(job),
+      job_class: self.class.name,
+      status: 'enqueued',
+      data: { progress: 0, total: total_resources }
+    }
+
+    @job_tracker = Spotlight::JobTracker.find_or_create_by(**params)
+  end
+
+  private
+
+    # Get total number of resources processed by the job.
+    def total_resources
+      resource_list(arguments.first).count
+    end
+end

--- a/app/jobs/spotlight/reindex_exhibit_job.rb
+++ b/app/jobs/spotlight/reindex_exhibit_job.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Override to enable Princeton-style exhibit indexing
+# See: https://github.com/projectblacklight/spotlight/blob/v3.0.3/app/jobs/spotlight/reindex_exhibit_job.rb
+module Spotlight
+  ##
+  # Reindex an exhibit by parallelizing resource indexing into multiple batches of reindex jobs
+  class ReindexExhibitJob < Spotlight::ApplicationJob
+    include Spotlight::JobTracking
+    include ::JobTracking
+    with_job_tracking(resource: ->(job) { job.arguments.first })
+
+    include Spotlight::LimitConcurrency
+
+    before_perform do |job|
+      progress.total = resource_list(job.arguments.first).count
+    end
+
+    def perform(exhibit, **)
+      exhibit = ExhibitProxy.new(exhibit)
+
+      # Remove resources not currently in collection
+      exhibit.members_to_remove_from_index.each(&:remove_from_solr)
+
+      # Enqueue a reindex job for each member resource
+      exhibit.resources.each do |resource|
+        Spotlight::ReindexJob.perform_later(resource, reports_on: job_tracker)
+      end
+
+      job_tracker.update(status: 'in_progress')
+    end
+
+    # Used to calculate the total number of resources in the processed by the job
+    def resource_list(exhibit)
+      ExhibitProxy.new(exhibit).members
+    end
+  end
+end

--- a/app/models/exhibit_proxy.rb
+++ b/app/models/exhibit_proxy.rb
@@ -15,8 +15,9 @@ class ExhibitProxy
     end
   end
 
-  def estimated_size
-    members.size
+  # Map all of the members to IIIFResource objects
+  def resources
+    @resources ||= members.map { |url| IIIFResource.find_or_initialize_by(url: url, exhibit_id: exhibit.id) }
   end
 
   def collection_manifest

--- a/spec/jobs/spotlight/reindex_exhibit_job_spec.rb
+++ b/spec/jobs/spotlight/reindex_exhibit_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Spotlight::ReindexExhibitJob do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:url1) { 'http://example.com/1/manifest' }
+  let(:manifest) { object_double(CollectionManifest.new, manifests: [{ "@id" => url1 }]) }
+
+  before do
+    allow(Spotlight::ReindexJob).to receive(:perform_later)
+    allow(CollectionManifest).to receive(:find_by_slug).and_return(manifest)
+  end
+
+  it 'runs the index job inline' do
+    described_class.perform_now(exhibit)
+
+    expect(Spotlight::ReindexJob).to have_received(:perform_later).once
+  end
+end


### PR DESCRIPTION
- Fixes repeat indexing job runs
- Allows resource monitor to return accurate job tracking data

Closes #1094 