### PR TITLE
404 when resource is requested on a nonexistent exhibit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,9 +21,14 @@ class ApplicationController < ActionController::Base
   rescue_from ActionView::MissingTemplate, with: :not_found
 
   def not_found
-    respond_to do |format|
-      format.html { render "pages/not_found", status: 404 }
-      format.all { head 404 }
+    # Error on exhibit when resource is requested on a nonexistent exhibit
+    if params[:id] && params[:exhibit_id] && @exhibit.nil?
+      redirect_to "/#{params[:exhibit_id]}"
+    else
+      respond_to do |format|
+        format.html { render "pages/not_found", status: 404 }
+        format.all { head 404 }
+      end
     end
   end
 

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -34,4 +34,14 @@ RSpec.describe "Errors", type: :request do
       expect(response.status).to eq 404
     end
   end
+
+  describe "resource is requested on a nonexistent exhibit" do
+    it "redirects to exhibit page and returns a 404" do
+      get "/not_an_exhibit/catalog/ab32bcd8-8586-4c38-8da2-0aaf33d17f57"
+
+      expect(response).to redirect_to("/not_an_exhibit")
+      follow_redirect!
+      expect(response.status).to eq 404
+    end
+  end
 end


### PR DESCRIPTION
closes #1200 