### PR TITLE
Fix reindexing exhibits with private resources.

### DIFF
--- a/app/jobs/spotlight/reindex_exhibit_job.rb
+++ b/app/jobs/spotlight/reindex_exhibit_job.rb
@@ -25,7 +25,9 @@ module Spotlight
       # Enqueue a reindex job for each member resource
       exhibit.resources.each do |resource|
         resource.save unless resource.persisted?
-        Spotlight::ReindexJob.perform_later(resource, reports_on: job_tracker)
+        # Don't reindex invalid resources - these are usually ones which are
+        # private and the app can't download manifests for.
+        Spotlight::ReindexJob.perform_later(resource, reports_on: job_tracker) if resource.valid?
       end
 
       job_tracker.update(status: 'in_progress')

--- a/spec/jobs/spotlight/reindex_exhibit_job_spec.rb
+++ b/spec/jobs/spotlight/reindex_exhibit_job_spec.rb
@@ -31,4 +31,11 @@ describe Spotlight::ReindexExhibitJob do
     expect(Spotlight::UpdateJobTrackersJob).to have_been_enqueued.exactly(:once)
     expect(Spotlight::ReindexJob).to have_been_enqueued.exactly(:once)
   end
+  it "skips over resources which there's no permission for" do
+    stub_manifest(url: url1, fixture: 'full_text_manifest.json', status: 403)
+    described_class.perform_now(exhibit)
+
+    expect(Spotlight::UpdateJobTrackersJob).not_to have_been_enqueued
+    expect(Spotlight::ReindexJob).not_to have_been_enqueued
+  end
 end


### PR DESCRIPTION
Refs #1267

The issue in 1267 was as follows:

ExhibitReindexJob starts, gets through the first 42 resources which are public, hits the 43rd item which is private and new, and tries to create it. It "saves", but doesn't throw an exception because it's not `save!`, and then tries to queue a job - but that new resource has no ID, because it failed validation, because it's a private URL. So the job errors, and only the first 42 get processed for indexing.