### PR TITLE
Autocomplete should return titles with no HTML.

### DIFF
--- a/config/initializers/monkeypatches/autocomplete_patch.rb
+++ b/config/initializers/monkeypatches/autocomplete_patch.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# SirTrevor uses autocomplete to populate boxes and item metadata. The title
+# with <li> in it breaks all the javascript - use the displays without the
+# lists to fix that bug.
+module AutocompletePatch
+  def autocomplete_json_response_for_document(doc)
+    super.merge(
+      title: CGI.unescapeHTML(view_context.document_presenter(doc).html_title.to_str)
+    )
+  end
+end
+
+Spotlight::Base.prepend(AutocompletePatch)


### PR DESCRIPTION
Fixes #1287.