### PR TITLE
Set exchange to be durable, but queue to not be.

### DIFF
--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -6,7 +6,10 @@ require_relative 'pom_config'
 Sneakers.configure(
   amqp: Pomegranate.config["events"]["server"],
   exchange: Pomegranate.config["events"]["exchange"],
-  exchange_type: :fanout,
+  exchange_options: {
+    type: :fanout,
+    durable: true
+  },
   handler: Sneakers::Handlers::Maxretry,
   before_fork: lambda {
     ActiveSupport.on_load(:active_record) do
@@ -23,7 +26,9 @@ Sneakers.logger.level = Logger::INFO
 
 WORKER_OPTIONS = {
   ack: true,
-  durable: Pomegranate.config["event_queue"]["durable"],
+  queue_options: {
+    durable: Pomegranate.config["event_queue"]["durable"]
+  },
   threads: 5,
   prefetch: 10,
   timeout_job_after: 60,

--- a/spec/workers/figgy_event_handler_spec.rb
+++ b/spec/workers/figgy_event_handler_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe FiggyEventHandler do
     end
 
     it "defaults to a durable queue" do
-      expect(described_class.queue_opts[:durable]).to eq true
+      expect(described_class.queue_opts[:queue_options][:durable]).to eq true
     end
   end
 end


### PR DESCRIPTION
Closes #1319

Pulled new option locations from here: https://github.com/jondot/sneakers/blob/master/lib/sneakers/configuration.rb

The old values were deprecated, and it was copying the durable option to both queue/exchange here:

https://github.com/jondot/sneakers/blob/31d0cb25dc5bbcfb0749567e9e0f80e6353fb66b/lib/sneakers/configuration.rb#L107-L108