### PR TITLE
Ensure that UpdateJobTrackersJob is always run synchronously

### DIFF
--- a/app/jobs/spotlight/update_job_trackers_job.rb
+++ b/app/jobs/spotlight/update_job_trackers_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ###
+  # Calls the #set_default_thumbnail method
+  # on the object passed in and calls save
+  ###
+  class UpdateJobTrackersJob < Spotlight::ApplicationJob
+    # Override to ensure that job is always run synchronously.
+    # See: https://github.com/pulibrary/dpul/issues/1295
+    def self.perform_later(job_tracker)
+      perform_now(job_tracker)
+    end
+
+    def perform(job_tracker)
+      reports_on = job_tracker.on
+
+      return unless reports_on.is_a? Spotlight::JobTracker
+
+      reports_on.update(status: 'completed') if reports_on.job_trackers.all?(&:completed?)
+      reports_on.update(status: 'failed') if reports_on.job_trackers.any?(&:failed?)
+
+      reports_on.update(data: { progress: reports_on.job_trackers.sum(&:progress), total: reports_on.job_trackers.sum(&:total) })
+    end
+  end
+end

--- a/spec/jobs/spotlight/reindex_exhibit_job_spec.rb
+++ b/spec/jobs/spotlight/reindex_exhibit_job_spec.rb
@@ -10,6 +10,7 @@ describe Spotlight::ReindexExhibitJob do
 
   before do
     allow(CollectionManifest).to receive(:find_by_slug).and_return(manifest)
+    allow(Spotlight::UpdateJobTrackersJob).to receive(:perform_now).and_call_original
   end
 
   after do
@@ -28,14 +29,14 @@ describe Spotlight::ReindexExhibitJob do
 
     described_class.perform_now(exhibit)
 
-    expect(Spotlight::UpdateJobTrackersJob).to have_been_enqueued.exactly(:once)
+    expect(Spotlight::UpdateJobTrackersJob).to have_received(:perform_now).exactly(:once)
     expect(Spotlight::ReindexJob).to have_been_enqueued.exactly(:once)
   end
   it "skips over resources which there's no permission for" do
     stub_manifest(url: url1, fixture: 'full_text_manifest.json', status: 403)
     described_class.perform_now(exhibit)
 
-    expect(Spotlight::UpdateJobTrackersJob).not_to have_been_enqueued
+    expect(Spotlight::UpdateJobTrackersJob).not_to have_received(:perform_now)
     expect(Spotlight::ReindexJob).not_to have_been_enqueued
   end
 end


### PR DESCRIPTION
Closes #1295 

Tested on staging. Works as expected.