### PR TITLE
Pin cancan in Gemfile to fix deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do
   gem 'byebug'
+  # see comment in spec/requests/pages_spec
+  gem 'cancancan', '3.1.0'
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'capistrano-rails-console'


### PR DESCRIPTION
Bundler refuses to run in deploy mode when there's a lock in the Gemfile.lock that's not reflected in the Gemfile. It says

```
01 You have deleted from the Gemfile:
01 * cancancan (= 3.1.0)
01 You are trying to install in deployment mode after changing
01 your Gemfile. Run `bundle install` elsewhere and add the
01 updated Gemfile.lock to version control.
```
