### PR TITLE
added consistent dark gray color to side nav

### DIFF
--- a/app/assets/stylesheets/overrides/_pages.scss
+++ b/app/assets/stylesheets/overrides/_pages.scss
@@ -2,9 +2,13 @@
   // Exhibit content page list
   ol.sidenav {
     // Non-active headings gray
-    li h2 a {
+    li h2 {
       color: #666d78;
     }
+    a {
+      color: #666d78 !important; 
+    }
+
     // Active headings bold
     li.active h2 {
       font-weight: bold;


### PR DESCRIPTION
closes #1332 

Side nav is now all dark gray. Note that the active page is still bolded though.

![Screen Shot 2022-04-20 at 11 30 27 AM](https://user-images.githubusercontent.com/66753486/164267673-b811495b-918a-42a5-a6f5-378f05b26d40.png)

