### PR TITLE
Remove Arial Unicode MS, which breaks connecting characters.

### DIFF
--- a/app/assets/stylesheets/variables/typography.scss
+++ b/app/assets/stylesheets/variables/typography.scss
@@ -5,7 +5,7 @@ $font-primary: "DejaVu Sans", "HelveticaNeue", Arial, sans-serif;
 $font-secondary: Georgia, Times, 'Times New Roman', serif;
 
 // used for lists and tabs
-$font-sans: "DejaVu Sans", "Arial Unicode MS", "Helvetica Neue", "Helvetica", "Arial", sans-serif !default;
+$font-sans: "DejaVu Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif !default;
 
 $text-color: #000 !default;
 $text-small: 12px;


### PR DESCRIPTION
Closes #1417

This was added in #662 and accidentally reverted in #1076 during our spotlight upgrade.

Before: 
![Screen Shot 2022-12-14 at 1 18 10 PM](https://user-images.githubusercontent.com/2806645/207716481-50de5656-ef0a-4ed4-b218-dd2c801f0b5b.png)



Now:
![Screen Shot 2022-12-14 at 1 16 59 PM](https://user-images.githubusercontent.com/2806645/207716380-66abbd1d-bca8-4000-8172-e0629f196a9c.png)
