### PR TITLE
Index full image at larger size and make it part of autocomplete response

### DIFF
--- a/app/services/iiif_manifest.rb
+++ b/app/services/iiif_manifest.rb
@@ -44,7 +44,7 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
   def full_image_url
     return super unless manifest['thumbnail'] && manifest['thumbnail']['service'] && manifest['thumbnail']['service']['@id']
 
-    "#{manifest['thumbnail']['service']['@id']}/full/!600,600/0/default.jpg"
+    "#{manifest['thumbnail']['service']['@id']}/full/!800,800/0/default.jpg"
   end
 
   # Override resources method to handle multi-volume work manifests

--- a/config/initializers/monkeypatches/blacklight_configuration_patch.rb
+++ b/config/initializers/monkeypatches/blacklight_configuration_patch.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Add the full image url to the autocomplete response
+module BlacklightConfigurationPatch
+  def default_autocomplete_field_list(config)
+    [
+      super,
+      Spotlight::Engine.config.full_image_field
+    ].flatten.join(' ')
+  end
+end
+
+Spotlight::BlacklightConfiguration.prepend(BlacklightConfigurationPatch)

--- a/config/initializers/spotlight_config.rb
+++ b/config/initializers/spotlight_config.rb
@@ -11,4 +11,3 @@ Spotlight::Engine.config.sir_trevor_widgets = %w[
   FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
   SolrDocumentsFeatures SolrDocumentsGrid SearchResults RecentItems
 ]
-Spotlight::Engine.config.default_autocomplete_params = { qf: "id^1000 full_title_tesim^100 id_ng full_title_ng", fl: "id full_title_tesim thumbnail_ssim content_metadata_iiif_manifest_field_ssi full_image_url_ssm" }

--- a/config/initializers/spotlight_config.rb
+++ b/config/initializers/spotlight_config.rb
@@ -6,9 +6,9 @@ Spotlight::Engine.config.upload_fields = []
 Spotlight::Engine.config.iiif_metadata_class = -> { ManifestMetadata }
 Spotlight::Engine.config.iiif_manifest_field = :content_metadata_iiif_manifest_field_ssi
 Spotlight::Engine.config.iiif_title_fields = "full_title_tesim"
-
 Spotlight::Engine.config.sir_trevor_widgets = %w[
   Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse
   FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
   SolrDocumentsFeatures SolrDocumentsGrid SearchResults RecentItems
 ]
+Spotlight::Engine.config.default_autocomplete_params = { qf: "id^1000 full_title_tesim^100 id_ng full_title_ng", fl: "id full_title_tesim thumbnail_ssim content_metadata_iiif_manifest_field_ssi full_image_url_ssm" }

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -50,13 +50,17 @@ RSpec.feature 'Catalog', type: :feature do
 
   context 'logged in as a site admin.' do
     let(:user) { FactoryBot.create(:site_admin, exhibit:) }
+    let(:full_image_url) { "https://example.com/iiif/2/95%2F60%2F3b%2F95%2Fintermediate_file/full/!800,800/0/default.jpg" }
 
     before do
       sign_in user
 
       Spotlight::SolrDocumentSidecar.create!(
         document:, exhibit:,
-        data: { 'full_title_tesim' => ['First', 'Second'] }
+        data: {
+          'full_title_tesim' => ['First', 'Second'],
+          'full_image_url_ssm' => [full_image_url]
+        }
       )
       document.make_public! exhibit
       document.reindex
@@ -71,6 +75,10 @@ RSpec.feature 'Catalog', type: :feature do
       # Autocomplete should have a title with no HTML. If there's HTML it breaks
       # the SirTrevor widgets.
       expect(doc["title"]).to eq "First, Second"
+      # provide the full image url; the front-end javascript isn't written to
+      # get these for MVWs so we'll just index these for everything at the
+      # size the sir trevor template uses
+      expect(doc["full_image_url"]).to eq full_image_url
     end
 
     scenario 'user searches for a collections with a keyword' do

--- a/spec/fixtures/iiif_responses.rb
+++ b/spec/fixtures/iiif_responses.rb
@@ -30,7 +30,11 @@ module IiifResponses
         }
       ],
       "thumbnail": {
-        "@id": 'uri://to-thumbnail'
+        "@id": 'uri://to-thumbnail',
+        "service": {
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "@id": "uri://to-thumbnail"
+        }
       },
       "sequences": [
         {

--- a/spec/models/iiif_resource_spec.rb
+++ b/spec/models/iiif_resource_spec.rb
@@ -288,7 +288,7 @@ describe IIIFResource do
         Blacklight.default_index.connection.commit
         docs = Blacklight.default_index.connection.get("select", params: { q: "*:*" })["response"]["docs"]
         scanned_resource_doc = docs.find { |x| x["full_title_tesim"] == ["Scanned Resource 1"] }
-        expect(scanned_resource_doc["full_image_url_ssm"]).to eq ["https://libimages1.princeton.edu/loris/plum/hq%2F37%2Fvn%2F61%2F6-intermediate_file.jp2/full/!600,600/0/default.jpg"]
+        expect(scanned_resource_doc["full_image_url_ssm"]).to eq ["https://libimages1.princeton.edu/loris/plum/hq%2F37%2Fvn%2F61%2F6-intermediate_file.jp2/full/!800,800/0/default.jpg"]
       end
     end
 

--- a/spec/services/iiif_manifest_spec.rb
+++ b/spec/services/iiif_manifest_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe IiifManifest do
       end
     end
 
+    describe 'full_image_url' do
+      it 'is a single-value text field' do
+        expect(manifest_service.to_solr[:full_image_url_ssm]).to eq "uri://to-thumbnail/full/!800,800/0/default.jpg"
+      end
+    end
+
     describe 'range-label' do
       it 'is a multi-value text field' do
         expect(manifest_service.to_solr["readonly_range-label_tesim"]).to eq ["range label value"]


### PR DESCRIPTION
advances #1287

Once this is deployed, the collection needs to be re-indexed, then the carousel widget needs to be edited to pull in the image again. after that it will show up at a larger size and not be blurry.