### PR TITLE
Add auth token to IIIFService response method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,6 +368,8 @@ GEM
       multi_json
     libdatadog (0.9.0.1.0)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-arm64-darwin)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-darwin)
       ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
@@ -408,6 +410,8 @@ GEM
       net-protocol
     net-ssh (7.0.1)
     nio4r (2.5.8)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
@@ -646,6 +650,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.5.4-arm64-darwin)
     sqlite3 (1.5.4-x86_64-darwin)
     sqlite3 (1.5.4-x86_64-linux)
     sshkit (1.21.3)
@@ -721,6 +726,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/app/services/iiif_service.rb
+++ b/app/services/iiif_service.rb
@@ -2,7 +2,8 @@
 
 class IiifService < ::Spotlight::Resources::IiifService
   def self.iiif_response(url)
-    resp = Spotlight::Resources::IiifService.http_client.get(url)
+    authorized_url = AuthorizedUrl.new(url:).to_s
+    resp = Spotlight::Resources::IiifService.http_client.get(authorized_url)
     if resp.success?
       resp.body
     else

--- a/app/values/authorized_url.rb
+++ b/app/values/authorized_url.rb
@@ -12,6 +12,8 @@ class AuthorizedUrl
 
   def to_s
     return url if auth_token.blank?
+    # Return url if auth token is already part of the url
+    return url if url.include?(auth_token)
 
     "#{url}?auth_token=#{auth_token}"
   end

--- a/spec/services/iiif_service_spec.rb
+++ b/spec/services/iiif_service_spec.rb
@@ -58,5 +58,26 @@ describe IiifService do
         expect(logger).to have_received(:warn).with("HTTP GET for #{url} failed with timeout")
       end
     end
+
+    context 'when an auth token is set' do
+      before do
+        allow(Pomegranate).to receive(:config).and_return({ "manifest_authorization_token" => "token" })
+      end
+
+      it 'appends the token to the request' do
+        expect(response).not_to be_empty
+        authorized_url = url + "?auth_token=token"
+        expect(http_client).to have_received(:get).with(authorized_url)
+      end
+
+      context 'with a url that already has a token' do
+        let(:url) { 'http://to-manifest1?auth_token=token' }
+
+        it 'does not append a new auth_token' do
+          expect(response).not_to be_empty
+          expect(http_client).to have_received(:get).with(url)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes indexing of Princeton-only MVWs. There was one additional spot to inject a token.

For real this time:
![Screenshot 2023-04-06 at 3 47 50 PM](https://user-images.githubusercontent.com/784196/230491631-ccf5afc5-d7a9-421d-a235-2e7d513cf244.png)


