### PR TITLE
Locale switches back to English when clicking 'Digital PUL' home button

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,5 +1,6 @@
 <header class="lux">
-  <library-header app-name="<%= application_name %>" abbr-name="DPUL" app-url="<%= root_path %>" theme="dark">
+  <library-header app-name="<%= application_name %>" abbr-name="DPUL" app-url="<%= "/" %>" theme="dark">
+   <%# app-url should be root_path, but is hardcoded right now to switch the locale back to english %> 
     <%= render partial: '/user_util_links' %>
   </library-header>
 </header>

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -1,0 +1,3 @@
+es:
+  blacklight:
+    application_name: 'Digital PUL'

--- a/spec/factories/language.rb
+++ b/spec/factories/language.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :language, class: 'Spotlight::Language' do
+    exhibit
+    locale { 'es' }
+  end
+end

--- a/spec/features/language_select_spec.rb
+++ b/spec/features/language_select_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Locale Selector', js: true do
   with_queue_adapter :inline
   let(:exhibit) { FactoryBot.create(:exhibit) }
-  let!(:language_es) { FactoryBot.create(:language, exhibit: exhibit, locale: 'es', public: true) }
+  let!(:language_es) { FactoryBot.create(:language, exhibit:, locale: 'es', public: true) }
 
   before { login_as user }
 

--- a/spec/features/language_select_spec.rb
+++ b/spec/features/language_select_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Locale Selector', js: true do
+  with_queue_adapter :inline
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let!(:language_es) { FactoryBot.create(:language, exhibit: exhibit, locale: 'es', public: true) }
+
+  before { login_as user }
+
+  describe 'switching locales' do
+    let(:user) { FactoryBot.create(:exhibit_visitor) }
+
+    it 'switches back to English when returning to "Digital PUL"' do
+      visit "/slug-1/home?locale=es"
+
+      expect(page).not_to have_css('input[placeholder="Search..."]')
+      expect(page).to have_css('input[placeholder="Buscar..."]')
+
+      find("a[title='Digital PUL']").click
+      expect(page).to have_css('input[placeholder="Search..."]')
+      expect(page).not_to have_css('input[placeholder="Buscar..."]')
+    end
+  end
+end


### PR DESCRIPTION
- Buttons for log in, favorites, dashboard, etc. in the user's top right dropdown still maintain the exhibit's locale. 
    - These links are generated through Spotlight, and seem to use the default_url_options function in the application controller, which looks like it just runs once for the whole page so I'm unclear on how to generate links with different locales for different areas of the page. 