### PR TITLE
Back out requirement for specific bundler version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ gem 'blacklight-gallery'
 gem 'blacklight-oembed'
 gem 'blacklight-spotlight', '~> 3.0'
 gem 'bootstrap', '~> 4.0'
-gem 'bundler', '2.3.18'
 gem 'ddtrace', require: "ddtrace/auto_instrument"
 gem 'devise', '~> 4.7.1'
 gem 'devise-guests', '~> 0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -742,7 +742,6 @@ DEPENDENCIES
   blacklight-oembed
   blacklight-spotlight (~> 3.0)
   bootstrap (~> 4.0)
-  bundler (= 2.3.18)
   byebug
   cancancan
   capistrano-passenger


### PR DESCRIPTION
This is no longer an issue since later versions of bundler first install
whatever bundler version the Gemfile.lock was generated with, then run
that to bundle. This will give us a little more flexibility on server
bundler versions.

refs pulibrary/princeton_ansible#3164
reverts #1366
