### PR TITLE
Retry resource enqueues up to 5 times

### DIFF
--- a/app/jobs/spotlight/reindex_exhibit_job.rb
+++ b/app/jobs/spotlight/reindex_exhibit_job.rb
@@ -17,20 +17,37 @@ module Spotlight
     end
 
     def perform(exhibit, **)
+      job_tracker.update(status: 'in_progress')
       exhibit = ExhibitProxy.new(exhibit)
 
       # Remove resources not currently in collection
       exhibit.members_to_remove_from_index.each(&:remove_from_solr)
 
+      errored_resources = enqueue_resources(exhibit.resources)
+      # do up to 5 retries
+      5.times do
+        break if errored_resources.blank?
+        errored_resources = enqueue_resources(errored_resources)
+      end
+      return if errored_resources.blank?
+      # errors after retries set failed status, with details sent to Honeybadger
+      Honeybadger.notify("Exhibit index failure on #{exhibit.slug}, with timeout errors on #{errored_resources.map(&:url).join(', ')}")
+      job_tracker.update(status: 'failed')
+    end
+
+    def enqueue_resources(resources_to_enqueue)
+      errored_resources = []
       # Enqueue a reindex job for each member resource
-      exhibit.resources.each do |resource|
+      resources_to_enqueue.each do |resource|
         resource.save unless resource.persisted?
         # Don't reindex invalid resources - these are usually ones which are
         # private and the app can't download manifests for.
         Spotlight::ReindexJob.perform_later(resource, reports_on: job_tracker) if resource.valid?
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed
+        # we've observed read timeout, but webmock to_timeout mocks open timeout
+        errored_resources.push(resource)
       end
-
-      job_tracker.update(status: 'in_progress')
+      errored_resources
     end
 
     # Used to calculate the total number of resources in the processed by the job

--- a/app/models/exhibit_proxy.rb
+++ b/app/models/exhibit_proxy.rb
@@ -4,6 +4,7 @@
 # so should always be re-instantiated before use.
 class ExhibitProxy
   attr_reader :exhibit
+  delegate :slug, to: :exhibit
   def initialize(exhibit)
     @exhibit = exhibit
   end

--- a/spec/jobs/spotlight/reindex_exhibit_job_spec.rb
+++ b/spec/jobs/spotlight/reindex_exhibit_job_spec.rb
@@ -34,11 +34,71 @@ describe Spotlight::ReindexExhibitJob do
     expect(Spotlight::ReindexJob).to have_been_enqueued.exactly(:once)
   end
 
+  it "works for resources which aren't persisted yet, even if they timeout on save validation" do
+    stub_request(:get, url1)
+      .to_return(status: 200, body: File.read(Rails.root.join("spec", "fixtures", "manifests", "full_text_manifest.json")), headers: { 'content-type' => 'application/ld+json' })
+    # head request should fail first, because of the save
+    stub_request(:head, url1)
+      .to_timeout.then
+      .to_return(status: 200, body: "", headers: { 'content-type' => 'application/ld+json' })
+    described_class.perform_now(exhibit)
+
+    expect(Spotlight::UpdateJobTrackersJob).to have_received(:perform_now).exactly(:once)
+    expect(Spotlight::ReindexJob).to have_been_enqueued.exactly(:once)
+  end
+
   it "skips over resources which there's no permission for" do
     stub_manifest(url: url1, fixture: 'full_text_manifest.json', status: 403)
     described_class.perform_now(exhibit)
 
     expect(Spotlight::UpdateJobTrackersJob).not_to have_received(:perform_now)
     expect(Spotlight::ReindexJob).not_to have_been_enqueued
+  end
+
+  context "when a resource head request times out" do
+    # these are the urls from spec/fixtures/manifests/2b88qc199.json
+    let(:url1) { "https://hydra-dev.princeton.edu/concern/scanned_resources/1r66j1149/manifest" }
+    let(:url2) { "https://hydra-dev.princeton.edu/concern/scanned_resources/44558d29f/manifest" }
+    let(:manifest) { object_double(CollectionManifest.new, manifests: [{ "@id" => url1 }, { "@id" => url2 }]) }
+
+    it "retries indexing" do
+      # get request can always succeed
+      stub_request(:get, url1)
+        .to_return(status: 200, body: File.read(Rails.root.join("spec", "fixtures", "manifests", "1r66j1149.json")), headers: { 'content-type' => 'application/ld+json' })
+      # head request should succeed first, because of the save
+      stub_request(:head, url1)
+        .to_return(status: 200, body: "", headers: { 'content-type' => 'application/ld+json' }).then
+        .to_timeout.then
+        .to_timeout.then
+        .to_return(status: 200, body: "", headers: { 'content-type' => 'application/ld+json' })
+      # url2 resource has no issues
+      stub_manifest(url: url2, fixture: "44558d29f.json")
+
+      allow(Honeybadger).to receive(:notify)
+      allow(Spotlight::ReindexJob).to receive(:perform_later)
+
+      described_class.perform_now(exhibit)
+
+      expect(Spotlight::ReindexJob).to have_received(:perform_later).twice
+      job_tracker = Spotlight::JobTracker.where(resource_id: exhibit.id).first
+      expect(job_tracker.status).to eq "completed"
+      expect(Honeybadger).not_to have_received(:notify)
+    end
+
+    it "notifies Honeybadger if all retries fail" do
+      stub_request(:head, url1).to_timeout
+      # url2 resource has no issues
+      stub_manifest(url: url2, fixture: "44558d29f.json")
+
+      allow(Spotlight::ReindexJob).to receive(:perform_later)
+      allow(Honeybadger).to receive(:notify)
+
+      described_class.perform_now(exhibit)
+
+      expect(Spotlight::ReindexJob).to have_received(:perform_later).once
+      job_tracker = Spotlight::JobTracker.where(resource_id: exhibit.id).first
+      expect(job_tracker.status).to eq "failed"
+      expect(Honeybadger).to have_received(:notify).with("Exhibit index failure on #{exhibit.slug}, with timeout errors on #{url1}")
+    end
   end
 end


### PR DESCRIPTION
advances pulibrary/figgy#6329 (close once reindex is done)

supercedes #1529 -- I thought I could push the `valid?` check down the stack, but the job won't run if the resource hasn't persisted, and failed validation can keep a resource from persisting. I didn't want to rewrite the reindex jobs to take a url instead of a resource, so this PR still proposes recording the job as a failure, after some retries. It also sends more details to honeybadger.