### PR TITLE
Add direction to uploaded items block.

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
@@ -30,7 +30,8 @@
   <% if uploaded_items_block.text? %>
     <%- # Customized just to remove mw-100 from here. %>
     <div class="text-col col-md-6">
-      <%= content_tag(:h3, uploaded_items_block.title) if uploaded_items_block.title.present? %>
+      <%- # Customized to change h3 to include dir %>
+      <%= content_tag(:h3, uploaded_items_block.title, dir: uploaded_items_block.title.to_s.dir) if uploaded_items_block.title.present? %>
       <%= sir_trevor_markdown uploaded_items_block.text %>
     </div>
   <% end %>


### PR DESCRIPTION
Closes #1553

I don't have a test for this mostly because it looks hard to test, and we didn't have one before.

Before:
![Screen Shot 2024-08-07 at 3 15 54 PM](https://github.com/user-attachments/assets/f797d6d4-8af1-4582-9e31-2f904a8ec2ea)

After:

![Screen Shot 2024-08-07 at 3 16 32 PM](https://github.com/user-attachments/assets/cacf983b-7819-4776-977d-b545a8cc06df)
