### PR TITLE
Index a field even when its label has been changed for the exhibit

### DIFF
--- a/app/services/iiif_manifest.rb
+++ b/app/services/iiif_manifest.rb
@@ -115,7 +115,7 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
         create_sidecars_for(*metadata.keys)
 
         metadata.each_with_object({}) do |(key, value), hash|
-          # The exhibit field for the key povides the solr field name, so we
+          # The exhibit field for the key provides the solr field name, so we
           # have to fetch that.
           #
           # We compare based on the slug rather than the label because

--- a/app/services/iiif_manifest.rb
+++ b/app/services/iiif_manifest.rb
@@ -115,7 +115,21 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
         create_sidecars_for(*metadata.keys)
 
         metadata.each_with_object({}) do |(key, value), hash|
-          next unless (field = exhibit_custom_fields[key])
+          # The exhibit field for the key povides the solr field name, so we
+          # have to fetch that.
+          #
+          # We compare based on the slug rather than the label because
+          # the label of the custom field may have been changed and not match
+          # the key any longer.
+          #
+          # Use a regex because it's possible for there to be
+          # `title`, `title-uuid`, and/or `title-sort`, for example, and
+          # we want to match only the key or the key with a uuid appended
+          # -- it doesn't matter whether you have the one with uuid appended or
+          # the one without; they both translate into the same solr field name
+          slug_regex = /^#{Regexp.quote(key.parameterize)}(-(\p{Alnum}){8}-(\p{Alnum}){4}-(\p{Alnum}){4}-(\p{Alnum}){4}-(\p{Alnum}){12})?/
+          next unless (custom_field_slug = slug_lookup.keys.find { |s| slug_regex.match(s) })
+          field = slug_lookup[custom_field_slug]
 
           field = BothFields.new(field)
           hash[field.field] = value
@@ -174,4 +188,10 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
     text = Array(FiggyGraphql.get_ocr_content_for_id(id: manifest_id)).map { |x| x.to_s.dup.force_encoding('UTF-8') }
     solr_hash["full_text_tesim"] = text
   end
+
+  private
+
+    def slug_lookup
+      @slug_lookup ||= exhibit_custom_fields.values.index_by(&:slug)
+    end
 end

--- a/app/services/iiif_manifest.rb
+++ b/app/services/iiif_manifest.rb
@@ -192,6 +192,6 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
   private
 
     def slug_lookup
-      @slug_lookup ||= exhibit_custom_fields.values.index_by(&:slug)
+      @slug_lookup ||= exhibit.custom_fields.index_by(&:slug)
     end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:concurrency: 2
+:concurrency: 5
 staging:
   :concurrency: 2
 production:

--- a/spec/features/indexing_spec.rb
+++ b/spec/features/indexing_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Indexing a figgy collection end-to-end test", type: :feature, js: true do
+  context "when a collection has a custom label on a field and a resource with an override title" do
+    with_queue_adapter :inline
+    let(:exhibit) { FactoryBot.create(:exhibit, title: "princeton", slug: "princeton-best") }
+
+    scenario "the field with the custom label indexes a value" do
+      sign_in FactoryBot.create(:site_admin)
+      stub_collections(fixture: "collections.json")
+      stub_manifest(url: "https://hydra-dev.princeton.edu/collections/2b88qc199/manifest", fixture: "2b88qc199.json")
+      stub_manifest(url: "https://hydra-dev.princeton.edu/concern/scanned_resources/1r66j1149/manifest", fixture: "1r66j1149.json")
+      stub_metadata(id: "1234567", fixture: "beaec815-6a34-4519-8ce8-40a89d3b1956")
+      stub_manifest(url: "https://hydra-dev.princeton.edu/concern/scanned_resources/44558d29f/manifest", fixture: "44558d29f.json")
+      Spotlight::ReindexExhibitJob.perform_now(exhibit)
+
+      # Add an override title
+      # visit "/princeton-best/catalog/7w62fb79e"
+      # click_link "Edit"
+      # fill_in "solr_document_sidecar_data_override-title_ssim", with: "Grecian Temples"
+      # click_button "Save changes"
+      # expect(page).to have_content "Grecian Temples"
+
+      # before changing the label, the field is there
+      visit "/princeton-best/catalog/7w62fb79g"
+      expect(page).to have_content "Alternative"
+
+      visit "/princeton-best/metadata_configuration/edit"
+
+      expect(page).not_to have_content "Alternative title"
+      within(find("tr[data-id='readonly_alternative_ssim']")) do
+        find("a.edit-in-place").click
+        find("#blacklight_configuration_index_fields_readonly_alternative_ssim_label", visible: :all).set("Alternative title")
+      end
+      click_button "Save changes"
+      expect(page).to have_content "Alternative title"
+
+      Spotlight::ReindexExhibitJob.perform_now(exhibit)
+
+      # after changing the label and reindexing, the field is still there
+      visit "/princeton-best/catalog/7w62fb79g"
+      expect(page).to have_content "Alternative"
+    end
+  end
+end

--- a/spec/features/indexing_spec.rb
+++ b/spec/features/indexing_spec.rb
@@ -16,16 +16,18 @@ RSpec.describe "Indexing a figgy collection end-to-end test", type: :feature, js
       stub_manifest(url: "https://hydra-dev.princeton.edu/concern/scanned_resources/44558d29f/manifest", fixture: "44558d29f.json")
       Spotlight::ReindexExhibitJob.perform_now(exhibit)
 
-      # Add an override title
-      # visit "/princeton-best/catalog/7w62fb79e"
-      # click_link "Edit"
-      # fill_in "solr_document_sidecar_data_override-title_ssim", with: "Grecian Temples"
-      # click_button "Save changes"
-      # expect(page).to have_content "Grecian Temples"
-
       # before changing the label, the field is there
       visit "/princeton-best/catalog/7w62fb79g"
       expect(page).to have_content "Alternative"
+
+      # Add an override title
+      # the bug exists without the override title, but an override title
+      # complicates the fix
+      visit "/princeton-best/catalog/7w62fb79e"
+      click_link "Edit"
+      fill_in "solr_document_sidecar_data_override-title_ssim", with: "Grecian Temples"
+      click_button "Save changes"
+      expect(page).to have_content "Grecian Temples"
 
       visit "/princeton-best/metadata_configuration/edit"
 

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -3,18 +3,11 @@
 require 'capybara/rspec'
 require 'selenium-webdriver'
 
-# there's a bug in capybara-screenshot that requires us to name
-#   the driver ":selenium" so we changed it from :headless_chrome"
-Capybara.register_driver :selenium do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(
-    args: %w[headless disable-gpu no-sandbox window-size=1536,1152]
-  )
-  Capybara::Selenium::Driver.new app,
-    browser: :chrome,
-    clear_session_storage: true,
-    clear_local_storage: true,
-    options:
-end
-
-Capybara.javascript_driver = :selenium
+Capybara.default_driver = :rack_test
+Capybara.javascript_driver =
+  if ENV["RUN_IN_BROWSER"] == "true"
+    :selenium_chrome
+  else
+    :selenium_chrome_headless
+  end
 Capybara.default_max_wait_time = 15


### PR DESCRIPTION
- **Simplify capybara selenium, add run in browser option**
- **Add failing test to demonstrate bug #1587**
- **Fix the bug**
- **Index more in dev at once**
 
advances #1587 