### PR TITLE
Render titles on browse page the same as on search page

### DIFF
--- a/app/presenters/rtl_index_presenter.rb
+++ b/app/presenters/rtl_index_presenter.rb
@@ -22,7 +22,7 @@ class RtlIndexPresenter < ::Blacklight::IndexPresenter
 
     # Checks if the requested field is the title field and if the configured
     # display title field exists on the document. If so, it returns the
-    # display title field value. This method allows pom to properly display
+    # display title field value. This method allows dpul to properly display
     # records with non-standard title fields.
     def value_from_symbol(field)
       default_title_field = @configuration.index.title_field.to_sym

--- a/app/processors/list_rendering.rb
+++ b/app/processors/list_rendering.rb
@@ -24,8 +24,11 @@ class ListRendering < Blacklight::Rendering::AbstractStep
   # don't make it a list.
   def use_join(config, context)
     return true if config.text_area == "1"
+
+    # always join on search and browse pages if it's anything other than the title field
     return true if context.try(:action_name) != "show" && config.field != "full_title_tesim"
 
-    context.try(:controller_name) != "catalog"
+    # don't join titles on search results and browse pages
+    !["catalog", "browse"].include?(context.try(:controller_name))
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Annotate rendered view with file names.
+  config.action_view.annotate_rendered_view_with_filenames = true
+
   # Use sidekiq in development so your front-end doesn't get tied up
   config.active_job.queue_adapter = :sidekiq
   config.i18n.fallbacks = true

--- a/spec/presenters/rtl_index_presenter_spec.rb
+++ b/spec/presenters/rtl_index_presenter_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe RtlIndexPresenter do
         )
         expect(presenter.heading).to eq '<ul><li dir="rtl">تضيح المقال</li><li dir="ltr">Tawḍīḥ al-maqāl</li></ul>'
       end
+
+      it 'renders heading on browse view as multiline' do
+        exhibit = FactoryBot.create(:exhibit)
+        presenter = described_class.new(
+          SolrDocument.new(full_title_tesim: title),
+          double(document_index_view_type: :current_view, should_render_field?: true, action_name: "index", controller_name: "browse"),
+          exhibit.blacklight_config
+        )
+        expect(presenter.heading).to eq '<ul><li dir="rtl">تضيح المقال</li><li dir="ltr">Tawḍīḥ al-maqāl</li></ul>'
+      end
     end
 
     context "when given a title with special characters" do


### PR DESCRIPTION
closes #1576 

![Screenshot 2025-02-07 at 3 30 08 PM](https://github.com/user-attachments/assets/cb494bf0-131a-4bed-a684-7f029366e6ec)