### PR TITLE
Silence deprecations in production logs.

### DIFF
--- a/config/initializers/deprecation.rb
+++ b/config/initializers/deprecation.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  Deprecation.default_deprecation_behavior = :silence if Rails.env.production?
+end


### PR DESCRIPTION
Same story as pulibrary/pulfalight#1512

This one's deployed, since if I let it run all day it'd cost money.
