### PR TITLE
Remove item-block class from _uploaded_items_block

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
@@ -1,4 +1,4 @@
-<div class="content-block items-block item-text row d-block clearfix">
+<div class="content-block item-text row d-block clearfix">
   <div class="items-col spotlight-flexbox <%= uploaded_items_block.text? ? "col-md-6" : "col-md-12" %> <%= uploaded_items_block.content_align == 'right' ? 'float-right float-end' : 'float-left float-start' %> uploaded-items-block">
     <% if uploaded_items_block.files.present? %>
       <% uploaded_items_block.files.each do |file| %>


### PR DESCRIPTION
Anna added this because of some style changes in Spotlight, but I don't
see it in Spotlight 4.6.1:
https://github.com/projectblacklight/spotlight/blob/v4.7.0/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb#L1

This is what was causing the images to squish down.

Closes #1611
