### PR TITLE
Index full_title_tesim from JSON-LD instead of manifest.

### DIFF
--- a/app/services/iiif_manifest.rb
+++ b/app/services/iiif_manifest.rb
@@ -13,6 +13,17 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
     add_full_text
     add_timestamps
     super
+    add_title_from_manifest_metadata
+    solr_hash
+  end
+
+  # Titles are single-valued in IIIF Manifests, but we need multiple titles from
+  # JSON-LD for transliterated titles.
+  def add_title_from_manifest_metadata
+    return unless title_fields.present? && solr_hash["readonly_title_tesim"].present?
+    Array.wrap(title_fields).each do |field|
+      solr_hash[field] = solr_hash["readonly_title_tesim"]
+    end
   end
 
   # In V3 manifests a thumbnail is in an array, and uses 'id' instead of '@id'

--- a/spec/fixtures/manifests/3c037d85-116f-490b-8d9b-62b3fe79a563.json
+++ b/spec/fixtures/manifests/3c037d85-116f-490b-8d9b-62b3fe79a563.json
@@ -1,0 +1,278 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@type": "sc:Manifest",
+  "@id": "https://figgy.princeton.edu/concern/ephemera_folders/3c037d85-116f-490b-8d9b-62b3fe79a563/manifest",
+  "label": "گلابو",
+  "description": "Gulabo - directed by Sangeeta & produced by Nimra Entertainment. Saima, Shaan, Babar Ali, Iftikhar Thakur, Resham, Babbu Baral, Nasir Chinyoti - cast. This is an action film in Punjabi language. \r\n",
+  "viewingHint": "individuals",
+  "metadata": [
+    {
+      "label": "Barcode",
+      "value": [
+        "32101111343388"
+      ]
+    },
+    {
+      "label": "Folder Number",
+      "value": [
+        "20"
+      ]
+    },
+    {
+      "label": "Title",
+      "value": [
+        "گلابو"
+      ]
+    },
+    {
+      "label": "Alternative Title",
+      "value": [
+        "Gulabo"
+      ]
+    },
+    {
+      "label": "Transliterated Title",
+      "value": [
+        "Gulābo"
+      ]
+    },
+    {
+      "label": "Language",
+      "value": [
+        "English",
+        "Urdu"
+      ]
+    },
+    {
+      "label": "Genre",
+      "value": [
+        "Posters"
+      ]
+    },
+    {
+      "label": "Width",
+      "value": [
+        "77"
+      ]
+    },
+    {
+      "label": "Height",
+      "value": [
+        "102"
+      ]
+    },
+    {
+      "label": "Page Count",
+      "value": [
+        "1"
+      ]
+    },
+    {
+      "label": "Keywords",
+      "value": [
+        "Pakistani Film Ephemera Collection"
+      ]
+    },
+    {
+      "label": "Creator",
+      "value": [
+        "ایس۔ خان ، illustrator"
+      ]
+    },
+    {
+      "label": "Contributor",
+      "value": [
+        "S. Khan, illustrator",
+        "Es. K̲h̲ān, illustrator",
+        "سنگیتا",
+        "Sangeeta, director",
+        "Sangītā, director",
+        "نمرہ انٹرٹینمنٹ",
+        "Nimra Entertainment, producer",
+        "Nimrah Inṭarṭenmanṭ, producer"
+      ]
+    },
+    {
+      "label": "Publisher",
+      "value": [
+        "لاہور : نمرہ فلمز",
+        "Lahore : Nimra Films ",
+        "Lāhaur : Nimrah Filmz"
+      ]
+    },
+    {
+      "label": "Geographic Origin",
+      "value": [
+        "Pakistan"
+      ]
+    },
+    {
+      "label": "Geo Subject",
+      "value": [
+        "Pakistan",
+        "Pakistan--Punjab"
+      ]
+    },
+    {
+      "label": "Date Created",
+      "value": [
+        "2008"
+      ]
+    },
+    {
+      "label": "Provenance",
+      "value": [
+        "Collection of Mr. Umar Ali"
+      ]
+    },
+    {
+      "label": "Subject",
+      "value": [
+        "Advertising",
+        "Arts",
+        "Motion pictures"
+      ]
+    },
+    {
+      "label": "Categories",
+      "value": [
+        {
+          "id": {
+            "id": "277cdbea-c0a8-4b7f-8bf6-de5ac07f95c3"
+          },
+          "internal_resource": "EphemeraVocabulary",
+          "created_at": "10/06/17 07:48:35 PM UTC",
+          "updated_at": "03/09/18 08:20:11 PM UTC",
+          "new_record": false,
+          "optimistic_lock_token": [],
+          "read_groups": [],
+          "read_users": [],
+          "edit_users": [],
+          "edit_groups": [],
+          "label": "Arts and culture",
+          "uri": "https://figgy.princeton.edu/ns/ephemeraSubjects/artsAndCulture",
+          "definition": null,
+          "member_of_vocabulary_id": [
+            {
+              "id": "94ac8724-64e5-4f46-bbe1-991d6cdd438f"
+            }
+          ]
+        },
+        {
+          "id": {
+            "id": "277cdbea-c0a8-4b7f-8bf6-de5ac07f95c3"
+          },
+          "internal_resource": "EphemeraVocabulary",
+          "created_at": "10/06/17 07:48:35 PM UTC",
+          "updated_at": "03/09/18 08:20:11 PM UTC",
+          "new_record": false,
+          "optimistic_lock_token": [],
+          "read_groups": [],
+          "read_users": [],
+          "edit_users": [],
+          "edit_groups": [],
+          "label": "Arts and culture",
+          "uri": "https://figgy.princeton.edu/ns/ephemeraSubjects/artsAndCulture",
+          "definition": null,
+          "member_of_vocabulary_id": [
+            {
+              "id": "94ac8724-64e5-4f46-bbe1-991d6cdd438f"
+            }
+          ]
+        },
+        {
+          "id": {
+            "id": "277cdbea-c0a8-4b7f-8bf6-de5ac07f95c3"
+          },
+          "internal_resource": "EphemeraVocabulary",
+          "created_at": "10/06/17 07:48:35 PM UTC",
+          "updated_at": "03/09/18 08:20:11 PM UTC",
+          "new_record": false,
+          "optimistic_lock_token": [],
+          "read_groups": [],
+          "read_users": [],
+          "edit_users": [],
+          "edit_groups": [],
+          "label": "Arts and culture",
+          "uri": "https://figgy.princeton.edu/ns/ephemeraSubjects/artsAndCulture",
+          "definition": null,
+          "member_of_vocabulary_id": [
+            {
+              "id": "94ac8724-64e5-4f46-bbe1-991d6cdd438f"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "sequences": [
+    {
+      "@type": "sc:Sequence",
+      "@id": "https://figgy.princeton.edu/concern/ephemera_folders/3c037d85-116f-490b-8d9b-62b3fe79a563/manifest/sequence/normal",
+      "rendering": [
+        {
+          "@id": "https://figgy.princeton.edu/catalog/3c037d85-116f-490b-8d9b-62b3fe79a563/pdf",
+          "label": "Download as PDF",
+          "format": "application/pdf"
+        }
+      ],
+      "canvases": [
+        {
+          "@type": "sc:Canvas",
+          "@id": "https://figgy.princeton.edu/concern/ephemera_folders/3c037d85-116f-490b-8d9b-62b3fe79a563/manifest/canvas/575a0b87-0eaa-474e-a866-214e63716b7a",
+          "label": "PK_0002_00049",
+          "rendering": [
+            {
+              "@id": "https://figgy.princeton.edu/downloads/575a0b87-0eaa-474e-a866-214e63716b7a/file/2309dfce-6870-4f6f-b3fc-372cda9d4d36",
+              "label": "Download the original file",
+              "format": "image/tiff"
+            }
+          ],
+          "width": 5654,
+          "height": 7537,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@type": "dctypes:Image",
+                "@id": "https://iiif-cloud.princeton.edu/iiif/2/01%2F58%2F14%2F015814a1001b4bb092bed7cbde74c98b%2Fintermediate_file/full/1000,/0/default.jpg",
+                "height": 7537,
+                "width": 5654,
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif-cloud.princeton.edu/iiif/2/01%2F58%2F14%2F015814a1001b4bb092bed7cbde74c98b%2Fintermediate_file",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "@id": "https://figgy.princeton.edu/concern/ephemera_folders/3c037d85-116f-490b-8d9b-62b3fe79a563/manifest/image/575a0b87-0eaa-474e-a866-214e63716b7a",
+              "on": "https://figgy.princeton.edu/concern/ephemera_folders/3c037d85-116f-490b-8d9b-62b3fe79a563/manifest/canvas/575a0b87-0eaa-474e-a866-214e63716b7a"
+            }
+          ]
+        }
+      ],
+      "viewingHint": "individuals"
+    }
+  ],
+  "seeAlso": {
+    "@id": "https://figgy.princeton.edu/catalog/3c037d85-116f-490b-8d9b-62b3fe79a563.jsonld",
+    "format": "application/ld+json"
+  },
+  "license": "http://rightsstatements.org/vocab/CNE/1.0/",
+  "thumbnail": {
+    "@id": "https://iiif-cloud.princeton.edu/iiif/2/01%2F58%2F14%2F015814a1001b4bb092bed7cbde74c98b%2Fintermediate_file/full/!200,150/0/default.jpg",
+    "service": {
+      "@context": "http://iiif.io/api/image/2/context.json",
+      "@id": "https://iiif-cloud.princeton.edu/iiif/2/01%2F58%2F14%2F015814a1001b4bb092bed7cbde74c98b%2Fintermediate_file",
+      "profile": "http://iiif.io/api/image/2/level2.json"
+    }
+  },
+  "logo": "https://figgy.princeton.edu/pul_logo_icon.png",
+  "service": {
+    "@context": "http://iiif.io/api/search/0/context.json",
+    "@id": "https://figgy.princeton.edu/catalog/3c037d85-116f-490b-8d9b-62b3fe79a563/iiif_search",
+    "profile": "http://iiif.io/api/search/0/search",
+    "label": "Search within this item"
+  }
+}

--- a/spec/fixtures/metadata/3c037d85-116f-490b-8d9b-62b3fe79a563.json
+++ b/spec/fixtures/metadata/3c037d85-116f-490b-8d9b-62b3fe79a563.json
@@ -1,0 +1,238 @@
+{
+  "@context": [
+    "https://bibdata.princeton.edu/context.json",
+    {
+      "wgs84": "http://www.w3.org/2003/01/geo/wgs84_pos#",
+      "latitude": {
+        "@id": "wgs84:lat"
+      },
+      "longitude": {
+        "@id": "wgs84:lon"
+      }
+    }
+  ],
+  "@id": "https://figgy.princeton.edu/catalog/3c037d85-116f-490b-8d9b-62b3fe79a563",
+  "edm_rights": {
+    "@id": "http://rightsstatements.org/vocab/CNE/1.0/",
+    "@type": "dcterms:RightsStatement",
+    "pref_label": "Copyright Not Evaluated"
+  },
+  "memberOf": [
+    {
+      "@id": "https://figgy.princeton.edu/catalog/cbdf1a60-1b5e-482a-a117-5cfa6643330a",
+      "@type": "pcdm:Collection",
+      "title": "Pakistani Film Ephemera Collection"
+    },
+    {
+      "@id": "https://figgy.princeton.edu/catalog/b9734420-6d54-4cc2-a082-2ea52128b4aa",
+      "@type": "pcdm:Collection",
+      "barcode": "32101046817340",
+      "label": "Box 26",
+      "box_number": "26"
+    }
+  ],
+  "system_created_at": "2024-10-12T11:39:10Z",
+  "system_updated_at": "2025-03-28T20:10:21Z",
+  "@type": "pcdm:Object",
+  "title": [
+    "گلابو",
+    "Gulābo"
+  ],
+  "alternative": [
+    "Gulabo"
+  ],
+  "creator": [
+    "ایس۔ خان ، illustrator"
+  ],
+  "contributor": [
+    "S. Khan, illustrator",
+    "Es. K̲h̲ān, illustrator",
+    "سنگیتا",
+    "Sangeeta, director",
+    "Sangītā, director",
+    "نمرہ انٹرٹینمنٹ",
+    "Nimra Entertainment, producer",
+    "Nimrah Inṭarṭenmanṭ, producer"
+  ],
+  "publisher": [
+    "لاہور : نمرہ فلمز",
+    "Lahore : Nimra Films ",
+    "Lāhaur : Nimrah Filmz"
+  ],
+  "barcode": "32101046817340",
+  "label": "Folder 20",
+  "is_part_of": "Pakistani Film Ephemera Collection",
+  "coverage": [
+    {
+      "@id": "https://figgy.princeton.edu/catalog/cba3b71d-9fae-4df7-abcb-faf19f2eb20f",
+      "@type": "skos:Concept",
+      "pref_label": "Pakistan",
+      "in_scheme": {
+        "@id": "https://figgy.princeton.edu/ns/ephemeraGeographicAreas",
+        "@type": "skos:ConceptScheme",
+        "pref_label": "Ephemera Geographic Areas"
+      },
+      "exact_match": {
+        "@id": "http://id.loc.gov/vocabulary/countries/pk"
+      }
+    },
+    {
+      "@id": "https://figgy.princeton.edu/catalog/eb1efb80-cbb0-4f8c-b9bc-ae632623675e",
+      "@type": "skos:Concept",
+      "pref_label": "Pakistan--Punjab",
+      "in_scheme": {
+        "@id": "https://figgy.princeton.edu/ns/ephemeraGeographicAreas",
+        "@type": "skos:ConceptScheme",
+        "pref_label": "Ephemera Geographic Areas"
+      },
+      "exact_match": {
+        "@id": {
+          "@id": "http://id.loc.gov/authorities/names/n80152695"
+        }
+      }
+    }
+  ],
+  "format": [
+    {
+      "@id": "https://figgy.princeton.edu/catalog/80d548de-cd6c-4aa3-9037-e40288a26d9f",
+      "@type": "skos:Concept",
+      "pref_label": "Posters",
+      "in_scheme": {
+        "@id": "https://figgy.princeton.edu/ns/ephemeraGenres",
+        "@type": "skos:ConceptScheme",
+        "pref_label": "Ephemera Genres"
+      },
+      "exact_match": {
+        "@id": "http://id.loc.gov/vocabulary/graphicMaterials/tgm008104"
+      }
+    }
+  ],
+  "origin_place": [
+    {
+      "@id": "https://figgy.princeton.edu/catalog/cba3b71d-9fae-4df7-abcb-faf19f2eb20f",
+      "@type": "skos:Concept",
+      "pref_label": "Pakistan",
+      "in_scheme": {
+        "@id": "https://figgy.princeton.edu/ns/ephemeraGeographicAreas",
+        "@type": "skos:ConceptScheme",
+        "pref_label": "Ephemera Geographic Areas"
+      },
+      "exact_match": {
+        "@id": "http://id.loc.gov/vocabulary/countries/pk"
+      }
+    }
+  ],
+  "language": [
+    {
+      "@id": "https://figgy.princeton.edu/catalog/2e615ab4-c542-45a0-95e5-56815128cea4",
+      "@type": "skos:Concept",
+      "pref_label": "English",
+      "in_scheme": {
+        "@id": "https://figgy.princeton.edu/ns/ephemeraLanguages",
+        "@type": "skos:ConceptScheme",
+        "pref_label": "Ephemera Languages"
+      },
+      "exact_match": {
+        "@id": {
+          "@id": "http://id.loc.gov/vocabulary/iso639-1/en"
+        }
+      }
+    },
+    {
+      "@id": "https://figgy.princeton.edu/catalog/262323b7-082e-43ee-8bab-e2efa0a59a70",
+      "@type": "skos:Concept",
+      "pref_label": "Urdu",
+      "in_scheme": {
+        "@id": "https://figgy.princeton.edu/ns/ephemeraLanguages",
+        "@type": "skos:ConceptScheme",
+        "pref_label": "Ephemera Languages"
+      },
+      "exact_match": {
+        "@id": "http://id.loc.gov/vocabulary/iso639-1/ur"
+      }
+    }
+  ],
+  "subject": [
+    {
+      "@id": "https://figgy.princeton.edu/catalog/86295cf5-c903-4475-8a08-ff89c932f4c0",
+      "@type": "skos:Concept",
+      "pref_label": "Advertising",
+      "in_scheme": {
+        "@id": "https://figgy.princeton.edu/ns/ephemeraSubjects/artsAndCulture",
+        "@type": "skos:ConceptScheme",
+        "pref_label": "Arts and culture"
+      },
+      "exact_match": {
+        "@id": {
+          "@id": "https://id.loc.gov/authorities/subjects/sh85001086.html"
+        }
+      }
+    },
+    {
+      "@id": "https://figgy.princeton.edu/catalog/ef9e7678-8e6f-4cd9-9a90-c292e91ab99b",
+      "@type": "skos:Concept",
+      "pref_label": "Arts",
+      "in_scheme": {
+        "@id": "https://figgy.princeton.edu/ns/ephemeraSubjects/artsAndCulture",
+        "@type": "skos:ConceptScheme",
+        "pref_label": "Arts and culture"
+      },
+      "exact_match": {
+        "@id": "http://id.loc.gov/authorities/subjects/sh85008324"
+      }
+    },
+    {
+      "@id": "https://figgy.princeton.edu/catalog/f0e684e6-3adb-4b78-a1ab-4517477ca67e",
+      "@type": "skos:Concept",
+      "pref_label": "Motion pictures",
+      "in_scheme": {
+        "@id": "https://figgy.princeton.edu/ns/ephemeraSubjects/artsAndCulture",
+        "@type": "skos:ConceptScheme",
+        "pref_label": "Arts and culture"
+      },
+      "exact_match": {
+        "@id": "http://id.loc.gov/authorities/subjects/sh85088084"
+      }
+    }
+  ],
+  "category": [
+    {
+      "@id": "https://figgy.princeton.edu/catalog/277cdbea-c0a8-4b7f-8bf6-de5ac07f95c3",
+      "@type": "skos:ConceptScheme",
+      "pref_label": "Arts and culture"
+    },
+    {
+      "@id": "https://figgy.princeton.edu/catalog/277cdbea-c0a8-4b7f-8bf6-de5ac07f95c3",
+      "@type": "skos:ConceptScheme",
+      "pref_label": "Arts and culture"
+    },
+    {
+      "@id": "https://figgy.princeton.edu/catalog/277cdbea-c0a8-4b7f-8bf6-de5ac07f95c3",
+      "@type": "skos:ConceptScheme",
+      "pref_label": "Arts and culture"
+    }
+  ],
+  "description": [
+    "Gulabo - directed by Sangeeta & produced by Nimra Entertainment. Saima, Shaan, Babar Ali, Iftikhar Thakur, Resham, Babbu Baral, Nasir Chinyoti - cast. This is an action film in Punjabi language. \r\n"
+  ],
+  "height": [
+    "102 cm"
+  ],
+  "width": [
+    "77 cm"
+  ],
+  "page_count": "1",
+  "created": "10/12/24 11:39:10 AM UTC",
+  "modified": "03/28/25 08:10:21 PM UTC",
+  "folder_number": "20",
+  "date_created": [
+    "2008"
+  ],
+  "provenance": "Collection of Mr. Umar Ali",
+  "transliterated_title": [
+    "Gulābo"
+  ],
+  "keywords": [
+    "Pakistani Film Ephemera Collection"
+  ]
+}

--- a/spec/models/iiif_resource_spec.rb
+++ b/spec/models/iiif_resource_spec.rb
@@ -295,7 +295,7 @@ describe IiifResource do
         Blacklight.default_index.connection.commit
         docs = Blacklight.default_index.connection.get("select", params: { q: "*:*" })["response"]["docs"]
         expect(docs.length).to eq 1
-        mvw_doc = docs.find { |x| x["full_title_tesim"] == ["MVW", "Second Title"] }
+        mvw_doc = docs.find { |x| x["full_title_tesim"] == ["Christopher and his kind, 1929-1939"] }
         expect(mvw_doc).to be_present
       end
     end
@@ -321,7 +321,7 @@ describe IiifResource do
         docs = Blacklight.default_index.connection.get("select", params: { q: "*:*" })["response"]["docs"]
         expect(docs.length).to eq 2
         scanned_resource_doc = docs.find { |x| x["full_title_tesim"] == ["Scanned Resource 1"] }
-        mvw_doc = docs.find { |x| x["full_title_tesim"] == ["MVW", "Second Title"] }
+        mvw_doc = docs.find { |x| x["full_title_tesim"] == ["Christopher and his kind, 1929-1939"] }
         expect(scanned_resource_doc["collection_id_ssim"]).to eq [mvw_doc["id"]]
         expect(mvw_doc["collection_id_ssim"]).to eq nil
       end

--- a/spec/models/iiif_resource_spec.rb
+++ b/spec/models/iiif_resource_spec.rb
@@ -378,6 +378,24 @@ describe IiifResource do
       end
     end
 
+    context "when given an ephemera folder with a title and transliterated title" do
+      let(:url) { "https://figgy.princeton.edu/concern/ephemera_folders/3c037d85-116f-490b-8d9b-62b3fe79a563/manifest" }
+      before do
+        stub_manifest(url:, fixture: "3c037d85-116f-490b-8d9b-62b3fe79a563.json")
+        stub_metadata(id: "3c037d85-116f-490b-8d9b-62b3fe79a563")
+      end
+      it "indexes both into full_title_tesim" do
+        exhibit = Spotlight::Exhibit.create title: 'Exhibit A'
+        resource = described_class.new url: url, exhibit: exhibit
+        expect(resource.save_and_index).to be_truthy
+
+        Blacklight.default_index.connection.commit
+        doc = Blacklight.default_index.connection.get("select", params: { q: "*:*" })["response"]["docs"].first
+
+        expect(doc["full_title_tesim"]).to eq ["گلابو", "Gulābo"]
+      end
+    end
+
     describe '#reindex' do
       let(:exhibit) { Spotlight::Exhibit.create title: 'Exhibit A' }
       let(:resource) { described_class.new url:, exhibit: }

--- a/spec/services/figgy_event_processor_spec.rb
+++ b/spec/services/figgy_event_processor_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe FiggyEventProcessor do
       Blacklight.default_index.connection.commit
       resource = Blacklight.default_index.connection.get("select", params: { q: "*:*" })["response"]["docs"].first
 
-      expect(resource["full_title_tesim"]).to eq ["Updated Record"]
+      expect(resource["sort_title_ssi"]).to eq "Updated Record"
     end
     context "when the record is gone" do
       it "doesn't blow up" do


### PR DESCRIPTION
In Figgy we recently started only sending manifests with the first title
[here](https://github.com/pulibrary/figgy/pull/6625/files#diff-8a0f639284de51b51abae05bfd1f16a1f3c13293e33d2af726d4044d6f5c43d5R47), because that's what the IIIF spec says. However, we were depending on it having multiple values for DPUL indexing.

This instead pulls the title from the JSON-LD if it's available.

Closes #1613