### PR TITLE
Always durable queues.

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -6,8 +6,6 @@ defaults: &defaults
   events:
     server: 'amqp://localhost:5672'
     exchange: 'plum_events'
-  event_queue:
-    durable: true
 
 development:
   <<: *defaults
@@ -31,5 +29,3 @@ staging:
   events:
     server: <%= ENV["POMEGRANATE_RABBITMQ_URL"] %>
     exchange: <%= ENV["POMEGRANATE_RABBITMQ_EXCHANGE"] %>
-  event_queue:
-    durable: false

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -27,7 +27,7 @@ Sneakers.logger.level = Logger::INFO
 WORKER_OPTIONS = {
   ack: true,
   queue_options: {
-    durable: Pomegranate.config["event_queue"]["durable"]
+    durable: true
   },
   threads: 5,
   prefetch: 10,


### PR DESCRIPTION
RabbitMQ 4.3 errors if we make a transient/non-durable queue.